### PR TITLE
Update for compatibility with 3.0.X and introduce new features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,5 @@
 SkyBlock for PocketMine-MP servers.
 ### Contributions
 You are free to contribute to this project, any kind of help is accepted.
-### Where can I download it?
-You can download it [here](https://poggit.pmmp.io/ci/giantquartz-plugin-collection/SkyBlock).
-### Can we use this plugin for production servers?
-You can use it as you want, but this plugin **is definitely a bad idea** if you want do a public server. This plugin has been think to work for 3 or 4 players, and it may fail if you create a lot of islands.
+### Where I can download it?
+You can download it [here](https://github.com/GiantAmethyst/SkyBlock/releases).

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,12 +1,11 @@
 ---
-name: SkyBlockPE
-author: xXSirButterXx/xXSirGamesXx, updated by 95CivicSi
-website: Not showing due to self-leak information.
-main: SkyBlock\Main
-version: 0.3.6
+name: SkyBlock
+author: GiantQuartz, updated by FiberglassCivic
+main: SkyBlock\SkyBlock
+version: 0.5.0
 api:
-- 3.0.0-ALPHA11
-- 3.0.0-ALPHA12
+- 3.0.0
+
 softdepend: [FormAPI]
 permissions:
   sbpe:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,16 +1,66 @@
-#                        Copyright (C) 2016 GiantQuartz
-#  ,ad8888ba,    88        88         db         88888888ba   888888888888  888888888888  
-# d8"'    `"8b   88        88        d88b        88      "8b       88                ,88  
-#d8'        `8b  88        88       d8'`8b       88      ,8P       88              ,88"   
-#88          88  88        88      d8'  `8b      88aaaaaa8P'       88            ,88"     
-#88          88  88        88     d8YaaaaY8b     88""""88'         88          ,88"       
-#Y8,    "88,,8P  88        88    d8""""""""8b    88    `8b         88        ,88"         
-# Y8a.    Y88P   Y8a.    .a8P   d8'        `8b   88     `8b        88       88"           
-#  `"Y8888Y"Y8a   `"Y8888Y"'   d8'          `8b  88      `8b       88       888888888888  
-#                                                                                                                                                                                  
-name: SkyBlock
-author: GiantQuartz
-website: http://twitter.com/GiantQuartz
-main: SkyBlock\SkyBlock
-version: "0.1.9"
-api: [3.0.0-ALPHA11]
+---
+name: SkyBlockPE
+author: xXSirButterXx/xXSirGamesXx, updated by 95CivicSi
+website: Not showing due to self-leak information.
+main: SkyBlock\Main
+version: 0.3.6
+api:
+- 3.0.0-ALPHA11
+- 3.0.0-ALPHA12
+softdepend: [FormAPI]
+permissions:
+  sbpe:
+    default: true
+    description: SkyBlockPE Base Permission
+  sbpe.cmd.help:
+    default: true
+    description: Allows player to see all the SkyBlockPE commands.
+  sbpe.cmd.create:
+    default: true
+    description:  Allows players to create an island
+  sbpe.cmd.join:
+    default: true
+    description: go to your island
+  sbpe.cmd.kick:
+    default: true
+    description: Kick someone off your island
+  sbpe.cmd.lock:
+    default: true
+    description: Lock people from going to your island
+  sbpe.cmd.sethome:
+    default: true
+    description: Sethome on your island
+  sbpe.cmd.home:
+    default: true
+    description: Go to your island home
+  sbpe.cmd.members:
+    default: true
+    description: List of members on your island.
+  sbpe.cmd.tp:
+    default: true
+    description: Teleport to an unlocked island
+  sbpe.cmd.optp:
+    default: op
+    description: Teleport to any island with someone online
+  sbpe.cmd.invite:
+    default: true
+    description: Invite a player to your island
+  sbpe.cmd.invite.accept:
+    default: true
+    description: Accept an invite
+  sbpe.cmd.invite.reject:
+    default: true
+    description: Reject an invite
+  sbpe.cmd.leave:
+    default: true
+    description: leave your island
+  sbpe.cmd.remove:
+    default: true
+    description: Delete your island
+  sbpe.cmd.makeleader:
+    default: true
+    description: make someone else the leader of your island
+  sbpe.cmd.version:
+    default: true
+    description: get version of SBPE
+...

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,13 +1,61 @@
-#                        Copyright (C) 2016 EntirelyQuartz                                                                                       
-#  ,ad8888ba,    88        88         db         88888888ba   888888888888  888888888888  
-# d8"'    `"8b   88        88        d88b        88      "8b       88                ,88  
-#d8'        `8b  88        88       d8'`8b       88      ,8P       88              ,88"   
-#88          88  88        88      d8'  `8b      88aaaaaa8P'       88            ,88"     
-#88          88  88        88     d8YaaaaY8b     88""""88'         88          ,88"       
-#Y8,    "88,,8P  88        88    d8""""""""8b    88    `8b         88        ,88"         
-# Y8a.    Y88P   Y8a.    .a8P   d8'        `8b   88     `8b        88       88"           
-#  `"Y8888Y"Y8a   `"Y8888Y"'   d8'          `8b  88      `8b       88       888888888888  
-#  
 ---
 enable-teamchat: true
+
+# Place the folder names of worlds that you do not want to be deleted when the cleanup command is used.
+# If this is left empty, the cleanup command will not work.  Example: [world, lobby, pvp, shop]
+protected-worlds: []
+
+
+# This will modify the contents of the starter chest for new islands.  If you put more than 27 entries
+# the plugin will only use the first 27 and the rest will be ignored.  If no items are found in the
+# config, a set of default items will be used instead.
+starting-items:
+  - id: 325
+    meta: 10
+    quantity: 1
+  - id: 79
+    meta: 0
+    quantity: 2
+  - id: 103
+    meta: 0
+    quantity: 1
+  - id: 352
+    meta: 0
+    quantity: 1
+  - id: 361
+    meta: 0
+    quantity: 1
+  - id: 83
+    meta: 0
+    quantity: 1
+  - id: 297
+    meta: 0
+    quantity: 1
+  - id: 295
+    meta: 0
+    quantity: 2
+
+
+# This modifies the items that users will find by mining cobblestone.  To set the chance option, use
+# a number greater than 0.  The higher the number, the more likely it will be that the player will
+# get that item compared to an item with a lower number.
+cobble-drops:
+  - id: 264
+    meta: 0
+    chance: 3
+  - id: 265
+    meta: 0
+    chance: 12
+  - id: 266
+    meta: 0
+    chance: 9
+  - id: 21
+    meta: 0
+    chance: 5
+  - id: 263
+    meta: 0
+    chance: 40
+  - id: 4
+    meta: 0
+    chance: 500
 ...

--- a/src/SkyBlock/PluginHearbeat.php
+++ b/src/SkyBlock/PluginHearbeat.php
@@ -2,32 +2,34 @@
 
 namespace SkyBlock;
 
-use pocketmine\scheduler\PluginTask;
 
-class PluginHearbeat extends PluginTask {
+use pocketmine\scheduler\Task;
+
+class PluginHearbeat extends Task {
 
     /** @var int */
     private $nextUpdate = 0;
+
+    /** @var SkyBlock */
+    private $instance;
 
     /**
      * PluginHearbeat constructor.
      *
      * @param SkyBlock $owner
      */
-    public function __construct(SkyBlock $owner) {
-        parent::__construct($owner);
+    public function __construct(SkyBlock $instance) {
+        $this->instance = $instance;
     }
 
     public function onRun(int $currentTick) {
         $this->nextUpdate++;
-        /** @var SkyBlock $owner */
-        $owner = $this->getOwner();
         if($this->nextUpdate == 120) {
             $this->nextUpdate = 0;
-            $owner->getIslandManager()->update();
+            $this->instance->getIslandManager()->update();
         }
-        $owner->getInvitationHandler()->tick();
-        $owner->getResetHandler()->tick();
+        $this->instance->getInvitationHandler()->tick();
+        $this->instance->getResetHandler()->tick();
     }
 
 }

--- a/src/SkyBlock/SkyBlock.php
+++ b/src/SkyBlock/SkyBlock.php
@@ -70,7 +70,7 @@ class SkyBlock extends PluginBase {
     }
 
     /**
-     * Return DynamicShopUI instance
+     * Return SkyBlock instance
      *
      * @return SkyBlock
      */

--- a/src/SkyBlock/SkyBlock.php
+++ b/src/SkyBlock/SkyBlock.php
@@ -184,7 +184,7 @@ class SkyBlock extends PluginBase {
      * Schedule the PluginHearbeat
      */
     public function setPluginHearbeat() {
-        $this->getServer()->getScheduler()->scheduleRepeatingTask(new PluginHearbeat($this), 20);
+        $this->getScheduler()->scheduleRepeatingTask(new PluginHearbeat($this), 20);
     }
 
     /**

--- a/src/SkyBlock/SkyBlock.php
+++ b/src/SkyBlock/SkyBlock.php
@@ -62,11 +62,11 @@ class SkyBlock extends PluginBase {
         $this->setUserInterface();
         $this->setPluginHearbeat();
         $this->registerCommand();
-        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Skyblock by xXSirGamesXx has been Enabled");
+        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Enabled");
     }
 
     public function onDisable() {
-        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Skyblock by xXSirGamesXx has been Disabled");
+        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Disabled");
     }
 
     /**

--- a/src/SkyBlock/SkyBlock.php
+++ b/src/SkyBlock/SkyBlock.php
@@ -3,13 +3,17 @@
 namespace SkyBlock;
 
 use pocketmine\plugin\PluginBase;
+use pocketmine\utils\TextFormat;
 use SkyBlock\chat\ChatHandler;
+use SkyBlock\command\SkyBlockCleanup;
 use SkyBlock\command\SkyBlockCommand;
+use SkyBlock\command\SkyBlockUICommand;
 use SkyBlock\generator\SkyBlockGeneratorManager;
 use SkyBlock\invitation\InvitationHandler;
 use SkyBlock\island\IslandManager;
 use SkyBlock\reset\ResetHandler;
 use SkyBlock\skyblock\SkyBlockManager;
+use SkyBlock\ui\SkyBlockForms;
 
 class SkyBlock extends PluginBase {
 
@@ -37,6 +41,9 @@ class SkyBlock extends PluginBase {
     /** @var SkyBlockListener */
     private $eventListener;
 
+    /** @var SkyBlockForms */
+    private $ui;
+
     public function onLoad() {
         if(!self::$object instanceof SkyBlock) {
             self::$object = $this;
@@ -52,17 +59,18 @@ class SkyBlock extends PluginBase {
         $this->setInvitationHandler();
         $this->setChatHandler();
         $this->setResetHandler();
+        $this->setUserInterface();
         $this->setPluginHearbeat();
         $this->registerCommand();
-        $this->getLogger()->info("SkyBlock by @GiantAmethyst was enabled.");
+        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Skyblock by xXSirGamesXx has been Enabled");
     }
 
     public function onDisable() {
-        $this->getLogger()->info("SkyBlock by @GiantAmethyst was disabled.");
+        $this->getLogger()->info(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "Skyblock by xXSirGamesXx has been Disabled");
     }
 
     /**
-     * Return Main instance
+     * Return DynamicShopUI instance
      *
      * @return SkyBlock
      */
@@ -98,7 +106,7 @@ class SkyBlock extends PluginBase {
     }
 
     /**
-     * Return EventListener instance
+     * Return SkyBlockListener instance
      *
      * @return SkyBlockListener
      */
@@ -133,6 +141,17 @@ class SkyBlock extends PluginBase {
         return $this->chatHandler;
     }
 
+	/**
+	 * Returns SkyBlockForms
+	 *
+	 *
+	 * @return SkyBlockForms
+	 */
+
+    public function getUserInterface(){
+    	return $this->ui;
+	}
+
     /**
      * Register SkyBlockGeneratorManager instance
      */
@@ -155,7 +174,7 @@ class SkyBlock extends PluginBase {
     }
 
     /**
-     * Register EventListener instance
+     * Register SkyBlockListener instance
      */
     public function setEventListener() {
         $this->eventListener = new SkyBlockListener($this);
@@ -189,11 +208,18 @@ class SkyBlock extends PluginBase {
         $this->chatHandler = new ChatHandler();
     }
 
+    public function setUserInterface() {
+    	$this->ui = new SkyBlockForms();
+	}
+
     /**
-     * Register SkyBlock command
+     * Register SkyBlock commands
      */
     public function registerCommand() {
-        $this->getServer()->getCommandMap()->register("skyblock", new SkyBlockCommand($this));
+        $this->getServer()->getCommandMap()->register("island", new SkyBlockCommand($this));
+        if($this->getServer()->getPluginManager()->getPlugin("FormAPI"))
+		$this->getServer()->getCommandMap()->register("skyblock", new SkyBlockUICommand($this));
+		$this->getServer()->getCommandMap()->register("sbcleanup", new SkyBlockCleanup($this));
     }
 
     public function initialize() {

--- a/src/SkyBlock/SkyBlockListener.php
+++ b/src/SkyBlock/SkyBlockListener.php
@@ -21,6 +21,7 @@ use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\Server;
 use pocketmine\utils\Config;
+use pocketmine\utils\MainLogger;
 use pocketmine\utils\TextFormat;
 use SkyBlock\chat\Chat;
 use SkyBlock\island\Island;
@@ -39,14 +40,47 @@ class SkyBlockListener implements Listener {
     public function __construct(SkyBlock $plugin) {
         $this->plugin = $plugin;
         $plugin->getServer()->getPluginManager()->registerEvents($this, $plugin);
-		$this->addItemMultipleTimes(3, Item::get(Item::DIAMOND), $this->cobbleDrops);
-		$this->addItemMultipleTimes(12, Item::get(Item::IRON_INGOT), $this->cobbleDrops);
-		$this->addItemMultipleTimes(9, Item::get(Item::GOLD_INGOT), $this->cobbleDrops);
-		$this->addItemMultipleTimes(5, Item::get(Item::LAPIS_ORE), $this->cobbleDrops);
-		$this->addItemMultipleTimes(40, Item::get(Item::COAL), $this->cobbleDrops);
-		$this->addItemMultipleTimes(500, Item::get(Item::COBBLESTONE), $this->cobbleDrops);
-		shuffle($this->cobbleDrops);
+        $this->reloadConfig();
     }
+
+    public function reloadConfig(){
+    	if($this->plugin instanceof SkyBlock){
+    		$this->cobbleDrops = [];
+			$config = $this->plugin->getConfig()->get("cobble-drops");
+    		foreach($config as $drop){
+    			if((isset($drop["id"]) and $drop["id"] !== Item::AIR) and isset($drop["meta"])){
+
+    				$id = $drop["id"];
+    				$meta = $drop["meta"];
+    				if($id < 0){
+    					$id = 0;
+					}
+					if($meta < 0){
+						$meta = 0;
+					}
+
+    				$item = Item::get($id, $meta);
+    				if($item instanceof Item){
+    					$chance = $drop["chance"];
+    					if($chance < 1){
+    						$chance = 1;
+						}
+    					$this->addItemMultipleTimes($chance, $item, $this->cobbleDrops);
+    					MainLogger::getLogger()->debug("SkyBlockListener: Adding {$item->getName()} to cobbleDrop pool $chance times.");
+					}
+				}
+			}
+			if(empty($this->cobbleDrops)){
+				$this->addItemMultipleTimes(3, Item::get(Item::DIAMOND), $this->cobbleDrops);
+				$this->addItemMultipleTimes(12, Item::get(Item::IRON_INGOT), $this->cobbleDrops);
+				$this->addItemMultipleTimes(9, Item::get(Item::GOLD_INGOT), $this->cobbleDrops);
+				$this->addItemMultipleTimes(5, Item::get(Item::LAPIS_ORE), $this->cobbleDrops);
+				$this->addItemMultipleTimes(40, Item::get(Item::COAL), $this->cobbleDrops);
+				$this->addItemMultipleTimes(500, Item::get(Item::COBBLESTONE), $this->cobbleDrops);
+			}
+			shuffle($this->cobbleDrops);
+		}
+	}
 
     /**
      * Try to register a player

--- a/src/SkyBlock/Utils.php
+++ b/src/SkyBlock/Utils.php
@@ -4,6 +4,8 @@ namespace SkyBlock;
 
 use pocketmine\level\Level;
 use pocketmine\level\Position;
+use pocketmine\Server;
+use pocketmine\utils\Config;
 
 class Utils {
 
@@ -28,6 +30,19 @@ class Utils {
     public static function getIslandPath($id) {
         return SkyBlock::getInstance()->getDataFolder() . "islands" . DIRECTORY_SEPARATOR . $id . ".json";
     }
+
+	/**
+	 * @param $id
+	 * @return null|Config
+	 */
+	public static function getUserConfig($userName) {
+		$fileName = SkyBlock::getInstance()->getDataFolder() . "users" . DIRECTORY_SEPARATOR . strtolower($userName) . ".json";
+		if(is_file($fileName)){
+			Server::getInstance()->getLogger()->info("SkyBlock Utils found user config for $userName");
+			return new Config($fileName, Config::JSON);
+		}
+		return null;
+	}
 
     /**
      * Return an unique island id
@@ -56,13 +71,10 @@ class Utils {
      */
     public static function parsePosition($string) {
         $array = explode(",", $string);
-        $array = array_map(function($v) {
-            return (float) $v;
-        }, $array);
         if(isset($array[3])) {
             $level = SkyBlock::getInstance()->getServer()->getLevelByName($array[0]);
             if($level instanceof Level) {
-                return new Position($array[1], $array[2], $array[3], $level);
+                return new Position((float) $array[1],(float) $array[2],(float) $array[3], $level);
             }
             else {
                 return null;

--- a/src/SkyBlock/command/SkyBlockCleanup.php
+++ b/src/SkyBlock/command/SkyBlockCleanup.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SkyBlock\command;
+
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\level\Level;
+use pocketmine\utils\Config;
+use SkyBlock\SkyBlock;
+
+class SkyBlockCleanup extends Command{
+	private $plugin;
+	private $worldsDir;
+	private $usersDir;
+	private $islandsDir;
+
+	public function __construct(SkyBlock $plugin){
+		$this->plugin = $plugin;
+		$this->worldsDir = $plugin->getServer()->getDataPath() . "worlds" . DIRECTORY_SEPARATOR;
+		$this->usersDir = $plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR;
+		$this->islandsDir = $plugin->getDataFolder() . "islands" . DIRECTORY_SEPARATOR;
+		parent::__construct("sbcleanup", "Cleans unused worlds and configuration files.", "§cUsage: /sbcleanup");
+	}
+
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
+		$validWorlds = ["ender", "nether", "pvp", "pvpisland", "skyblock", "world"];
+		$userConfigs = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->usersDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::CHILD_FIRST);
+		foreach($userConfigs as $configFile) {
+			if(!$configFile->isDir()){
+				$config = new Config($configFile->getRealPath(), Config::JSON);
+				$island = $config->get("island");
+				array_push($validWorlds, $island);
+			}
+		}
+		$worldFolders = glob($this->worldsDir . "*");
+		foreach($worldFolders as $worldFolder){
+			$string = $this->worldsDir;
+			$worldName = str_replace($string, "", $worldFolder);
+			if(!in_array($worldName, $validWorlds)){
+				$world = $this->plugin->getServer()->getLevelByName($worldName);
+				if($world instanceof Level) {
+					$this->plugin->getServer()->unloadLevel($world);
+				}
+				$config = $this->islandsDir . $worldName . ".json";
+
+				$files = new \RecursiveIteratorIterator(
+					new \RecursiveDirectoryIterator($worldFolder . DIRECTORY_SEPARATOR, \RecursiveDirectoryIterator::SKIP_DOTS),
+					\RecursiveIteratorIterator::CHILD_FIRST
+				);
+
+				foreach ($files as $fileinfo) {
+					$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+					$todo($fileinfo->getRealPath());
+				}
+
+				rmdir($worldFolder . DIRECTORY_SEPARATOR);
+				if(is_file($config)){
+					unlink($config);
+				}
+			}
+		}
+
+	}
+}

--- a/src/SkyBlock/command/SkyBlockCleanup.php
+++ b/src/SkyBlock/command/SkyBlockCleanup.php
@@ -5,6 +5,7 @@ namespace SkyBlock\command;
 
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
+use pocketmine\command\ConsoleCommandSender;
 use pocketmine\level\Level;
 use pocketmine\utils\Config;
 use SkyBlock\SkyBlock;
@@ -24,43 +25,53 @@ class SkyBlockCleanup extends Command{
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){
-		$validWorlds = ["ender", "nether", "pvp", "pvpisland", "skyblock", "world"];
-		$userConfigs = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->usersDir, \RecursiveDirectoryIterator::SKIP_DOTS),
-			\RecursiveIteratorIterator::CHILD_FIRST);
-		foreach($userConfigs as $configFile) {
-			if(!$configFile->isDir()){
-				$config = new Config($configFile->getRealPath(), Config::JSON);
-				$island = $config->get("island");
-				array_push($validWorlds, $island);
+		if($sender instanceof ConsoleCommandSender){
+			$validWorlds = $this->plugin->getConfig()->get("protected-worlds");
+			if(!empty($validWorlds)){
+				$counter = 0;
+				$userConfigs = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->usersDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+					\RecursiveIteratorIterator::CHILD_FIRST);
+				foreach($userConfigs as $configFile){
+					if(!$configFile->isDir()){
+						$config = new Config($configFile->getRealPath(), Config::JSON);
+						$island = $config->get("island");
+						array_push($validWorlds, $island);
+					}
+				}
+				$worldFolders = glob($this->worldsDir . "*");
+				foreach($worldFolders as $worldFolder){
+					$string = $this->worldsDir;
+					$worldName = str_replace($string, "", $worldFolder);
+					if(!in_array($worldName, $validWorlds)){
+						$world = $this->plugin->getServer()->getLevelByName($worldName);
+						if($world instanceof Level){
+							$this->plugin->getServer()->unloadLevel($world);
+						}
+						$config = $this->islandsDir . $worldName . ".json";
+
+						$files = new \RecursiveIteratorIterator(
+							new \RecursiveDirectoryIterator($worldFolder . DIRECTORY_SEPARATOR, \RecursiveDirectoryIterator::SKIP_DOTS),
+							\RecursiveIteratorIterator::CHILD_FIRST
+						);
+
+						foreach($files as $fileinfo){
+							$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+							$todo($fileinfo->getRealPath());
+							$counter++;
+						}
+
+						rmdir($worldFolder . DIRECTORY_SEPARATOR);
+						if(is_file($config)){
+							unlink($config);
+						}
+					}
+				}
+				$sender->sendMessage("sbcleanup: Completed!  Removed $counter files and directories.");
+			}else{
+				$sender->sendMessage("The configuration file needs to be updated before using the sbcleanup command.");
 			}
+		} else {
+			$sender->sendMessage("This command must be run from the console.");
 		}
-		$worldFolders = glob($this->worldsDir . "*");
-		foreach($worldFolders as $worldFolder){
-			$string = $this->worldsDir;
-			$worldName = str_replace($string, "", $worldFolder);
-			if(!in_array($worldName, $validWorlds)){
-				$world = $this->plugin->getServer()->getLevelByName($worldName);
-				if($world instanceof Level) {
-					$this->plugin->getServer()->unloadLevel($world);
-				}
-				$config = $this->islandsDir . $worldName . ".json";
-
-				$files = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator($worldFolder . DIRECTORY_SEPARATOR, \RecursiveDirectoryIterator::SKIP_DOTS),
-					\RecursiveIteratorIterator::CHILD_FIRST
-				);
-
-				foreach ($files as $fileinfo) {
-					$todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
-					$todo($fileinfo->getRealPath());
-				}
-
-				rmdir($worldFolder . DIRECTORY_SEPARATOR);
-				if(is_file($config)){
-					unlink($config);
-				}
-			}
-		}
-
 	}
 }

--- a/src/SkyBlock/command/SkyBlockCommand.php
+++ b/src/SkyBlock/command/SkyBlockCommand.php
@@ -78,7 +78,6 @@ class SkyBlockCommand extends Command {
                                     else {
                                         $this->plugin->getSkyBlockManager()->generateIsland($sender, "basic");
                                         $this->sendMessage($sender, "§l§a✔§fYou successfully created a island!");
-                                        $this->plugin->getServer()->dispatchCommand($sender, "sb");
                                     }
                                 }
                             }

--- a/src/SkyBlock/command/SkyBlockCommand.php
+++ b/src/SkyBlock/command/SkyBlockCommand.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace SkyBlock\command;
 
 use SkyBlock\Utils;
@@ -9,550 +8,492 @@ use pocketmine\level\Position;
 use pocketmine\Player;
 use pocketmine\utils\Config;
 use pocketmine\utils\TextFormat;
-use SkyBlock\invitation\Invitation;
 use SkyBlock\island\Island;
 use SkyBlock\SkyBlock;
 use SkyBlock\reset\Reset;
 
-class SkyBlockCommand extends Command {
+class SkyBlockCommand extends Command{
+	/** @var SkyBlock */
+	private $plugin;
 
-    /** @var SkyBlock */
-    private $plugin;
+	/**
+	 * SkyBlockCommand constructor.
+	 *
+	 * @param SkyBlock $plugin
+	 */
+	public function __construct(SkyBlock $plugin){
+		$this->plugin = $plugin;
+		parent::__construct("island", "SkyBlock command", "§cUsage: /skyblock", ["is"]);
+	}
 
-    /**
-     * SkyBlockCommand constructor.
-     *
-     * @param SkyBlock $plugin
-     */
-    public function __construct(SkyBlock $plugin) {
-        $this->plugin = $plugin;
-        parent::__construct("skyblock", "Main SkyBlock command", "Usage: /skyblock", ["sb"]);
-    }
+	public function sendMessage(Player $sender, $message){
+		$sender->sendMessage(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . $message);
+	}
 
-    public function sendMessage(Player $sender, $message) {
-        $sender->sendMessage(TextFormat::GREEN . "- " . TextFormat::WHITE . $message);
-    }
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
+		if($sender instanceof Player){
+			if(isset($args[0])){
+				switch($args[0]){
+					case "join":
+						if($sender->hasPermission('sbpe.cmd.join') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									$island->addPlayer($sender);
+									$level = $this->plugin->getServer()->getLevelByName($island->getIdentifier());
+									$spawnPoint = $level->getSpawnLocation();
+									$sender->teleport($spawnPoint);
+									$this->sendMessage($sender, "§l§a✔§fYou were teleported to your island home succesfully");
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!!");
+								}
+							}
+						}
+						break;
+					case "create":
+						if($sender->hasPermission('sbpe.cmd.create') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$reset = $this->plugin->getResetHandler()->getResetTimer($sender);
+								if($reset instanceof Reset){
+									$minutes = Utils::printSeconds($reset->getTime());
+									$this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to create a new island in §4{$minutes} §cminutes");
+								}else{
+									$skyBlockManager = $this->plugin->getSkyBlockGeneratorManager();
+									if(isset($args[1])){
+										if($skyBlockManager->isGenerator($args[1])){
+											$this->plugin->getSkyBlockManager()->generateIsland($sender, $args[1]);
+											$this->sendMessage($sender, "§l§a✔§fYou successfully created a {$skyBlockManager->getGeneratorIslandName($args[1])} island!");
+										}else{
+											$this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid SkyBlock generator!");
+										}
+									}else{
+										$this->plugin->getSkyBlockManager()->generateIsland($sender, "basic");
+										$this->sendMessage($sender, "§l§a✔§fYou successfully created a island!");
+										$this->plugin->getServer()->dispatchCommand($sender, "sb");
+									}
+								}
+							}else{
+								$this->sendMessage($sender, "§l§c✖§f §cYou already have a SkyBlock island!");
+							}
+						}
+						break;
+					case "home":
+						$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+						if(empty($config->get("island"))){
+							$this->sendMessage($sender, "§c✖§f You do not have an island!");
+						}else{
+							$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+							if($island instanceof Island){
+								$home = $island->getHomePosition();
+								if($home instanceof Position){
+									$sender->teleport($home);
+									$this->sendMessage($sender, "§a✔§f You have been teleported to your island home");
+								}else{
+									$this->sendMessage($sender, "§c➡§f Your island is not home yet!");
+								}
+							}else{
+								$this->sendMessage($sender, "§c✖§f You do not have an island!");
+							}
+						}
+						break;
+					case "sethome":
+						$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+						if(empty($config->get("island"))){
+							$this->sendMessage($sender, "§c✖§f You do not have an island!");
+						}else{
+							$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+							if($island instanceof Island){
+								if($island->getOwnerName() == strtolower($sender->getName())){
+									if($sender->getLevel()->getName() == $config->get("island")){
+										$island->setHomePosition($sender->getPosition());
+										$this->sendMessage($sender, "§a✔§f You have successfully set up your island home!");
+									}else{
+										$this->sendMessage($sender, "§c✖§f You have to stay in your island to set home!");
+									}
+								}else{
+									$this->sendMessage($sender, "§c➡§f You have to be the island's leader to do this!");
+								}
+							}else{
+								$this->sendMessage($sender, "§c✖§f You do not have an island!");
+							}
+						}
+						break;
 
-    public function execute(CommandSender $sender, string $commandLabel, array $args) {
-        if($sender instanceof Player) {
-            if(isset($args[0])) {
-                switch($args[0]) {
-                    case "join":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                $island->addPlayer($sender);
-                                $sender->teleport(new Position(15, 7, 10, $this->plugin->getServer()->getLevelByName($island->getIdentifier())));
-                                $this->sendMessage($sender, "You were teleported to your island home");
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!!");
-                            }
-                        }
-                        break;
-                    case "create":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $reset = $this->plugin->getResetHandler()->getResetTimer($sender);
-                            if($reset instanceof Reset) {
-                                $minutes = Utils::printSeconds($reset->getTime());
-                                $this->sendMessage($sender, "You'll be able to create a new island in {$minutes} minutes");
-                            }
-                            else {
-                                $skyBlockManager = $this->plugin->getSkyBlockGeneratorManager();
-                                if(isset($args[1])) {
-                                    if($skyBlockManager->isGenerator($args[1])) {
-                                        $this->plugin->getSkyBlockManager()->generateIsland($sender, $args[1]);
-                                        $this->sendMessage($sender, "You successfully created a {$skyBlockManager->getGeneratorIslandName($args[1])} island!");
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "That isn't a valid SkyBlock generator!");
-                                    }
-                                }
-                                else {
-                                    $this->plugin->getSkyBlockManager()->generateIsland($sender, "basic");
-                                    $this->sendMessage($sender, "You successfully created a island!");
-                                }
-                            }
-                        }
-                        else {
-                            $this->sendMessage($sender, "You already got a skyblock island!");
-                        }
-                        break;
-                    case "home":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                $home = $island->getHomePosition();
-                                if($home instanceof Position) {
-                                    $sender->teleport($home);
-                                    $this->sendMessage($sender, "You have been teleported to your island home");
-                                }
-                                else {
-                                    $this->sendMessage($sender, "Your island haven't a home position set!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!!");
-                            }
-                        }
-                        break;
-                    case "sethome":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    if($sender->getLevel()->getName() == $config->get("island")) {
-                                        $island->setHomePosition($sender->getPosition());
-                                        $this->sendMessage($sender, "You set your island home successfully!");
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "You must be in your island to set home!");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the island leader to do this!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!!");
-                            }
-                        }
-                        break;
-                    case "kick":
-                    case "expel":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    if(isset($args[1])) {
-                                        $player = $this->plugin->getServer()->getPlayer($args[1]);
-                                        if($player instanceof Player and $player->isOnline()) {
-                                            if($player->getLevel()->getName() == $island->getIdentifier()) {
-                                                $player->teleport($this->plugin->getServer()->getDefaultLevel()->getSafeSpawn());
-                                                $this->sendMessage($sender, "{$player->getName()} has been kicked from your island!");
-                                            }
-                                            else {
-                                                $this->sendMessage($sender, "The player isn't in your island!");
-                                            }
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "That isn't a valid player");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "Usage: /skyblock expel <name>");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must the island owner to expel anyone");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!");
-                            }
-                        }
-                        break;
-                    case "lock":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    $island->setLocked(!$island->isLocked());
-                                    $locked = ($island->isLocked()) ? "locked" : "unlocked";
-                                    $this->sendMessage($sender, "Your island has been {$locked}!");
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the island owner to do this!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!");
-                            }
-                        }
-                        break;
-                    case "invite":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You haven't a island!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    if(isset($args[1])) {
-                                        $player = $this->plugin->getServer()->getPlayer($args[1]);
-                                        if($player instanceof Player and $player->isOnline()) {
-                                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
-                                            if(empty($config->get("island"))) {
-                                                $this->plugin->getInvitationHandler()->addInvitation($sender, $player, $island);
-                                                $this->sendMessage($sender, "You sent a invitation to {$player->getName()}!");
-                                                $this->sendMessage($player, "{$sender->getName()} invited you to his island! Do /skyblock <accept/reject> {$sender->getName()}");
-                                            }
-                                            else {
-                                                $this->sendMessage($sender, "This player is already in a island!");
-                                            }
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "{$args[1]} isn't a valid player!");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "Usage: /skyblock invite <player>");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the island owner to do this!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You haven't a island!!");
-                            }
-                        }
-                        break;
-                    case "accept":
-                        if(isset($args[1])) {
-                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                            if(empty($config->get("island"))) {
-                                $player = $this->plugin->getServer()->getPlayer($args[1]);
-                                if($player instanceof Player and $player->isOnline()) {
-                                    $invitation = $this->plugin->getInvitationHandler()->getInvitation($player);
-                                    if($invitation instanceof Invitation) {
-                                        if($invitation->getSender() === $player) {
-                                            $invitation->accept();
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "You haven't a invitation from {$player->getName()}!");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "You haven't a invitation from {$player->getName()}");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "{$args[1]} is not a valid player");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You cannot be in a island if you want join another island!");
-                            }
-                        }
-                        else {
-                            $this->sendMessage($sender, "Usage: /skyblock accept <sender name>");
-                        }
-                        break;
-                    case "deny":
-                    case "reject":
-                        if(isset($args[1])) {
-                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                            if(empty($config->get("island"))) {
-                                $player = $this->plugin->getServer()->getPlayer($args[1]);
-                                if($player instanceof Player and $player->isOnline()) {
-                                    $invitation = $this->plugin->getInvitationHandler()->getInvitation($player);
-                                    if($invitation instanceof Invitation) {
-                                        if($invitation->getSender() === $player) {
-                                            $invitation->deny();
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "You haven't a invitation from {$player->getName()}!");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "You haven't a invitation from {$player->getName()}");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "{$args[1]} is not a valid player");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You cannot be in a island if you want reject another island!");
-                            }
-                        }
-                        else {
-                            $this->sendMessage($sender, "Usage: /skyblock accept <sender name>");
-                        }
-                        break;
-                    case "members":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to use this command!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                $this->sendMessage($sender, "____| {$island->getOwnerName()}'s Members |____");
-                                $i = 1;
-                                foreach($island->getAllMembers() as $member) {
-                                    $this->sendMessage($sender, "{$i}. {$member}");
-                                    $i++;
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to use this command!!");
-                            }
-                        }
-                        break;
-                    case "disband":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to disband it!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    foreach($island->getAllMembers() as $member) {
-                                        $memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
-                                        $memberConfig->set("island", "");
-                                        $memberConfig->save();
-                                    }
-                                    $this->plugin->getIslandManager()->removeIsland($island);
-                                    $this->plugin->getResetHandler()->addResetTimer($sender);
-                                    $this->sendMessage($sender, "You successfully deleted the island!");
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the owner to disband the island!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to disband it!!");
-                            }
-                        }
-                        break;
-                    case "makeleader":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to set a new leader!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    if(isset($args[1])) {
-                                        $player = $this->plugin->getServer()->getPlayer($args[1]);
-                                        if($player instanceof Player and $player->isOnline()) {
-                                            $playerConfig = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
-                                            $playerIsland = $this->plugin->getIslandManager()->getOnlineIsland($playerConfig->get("island"));
-                                            if($island === $playerIsland) {
-                                                $island->setOwnerName($player->getName());
-                                                $island->addPlayer($player);
-                                                $island->update();
-                                                $this->sendMessage($sender, "You sent the ownership to {$player->getName()}");
-                                                $this->sendMessage($player, "You get your island ownership by {$sender->getName()}");
-                                            }
-                                            else {
-                                                $this->sendMessage($sender, "The player should be on your island!");
-                                            }
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "{$args[1]} isn't a valid player!");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "Usage: /skyblock makeleader <player>");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the island leader to do this!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to set a new leader!!");
-                            }
-                        }
-                        break;
-                    case "leave":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to leave it!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    $this->sendMessage($sender, "You cannot leave a island if your the owner! Maybe you can try use /skyblock disband");
-                                }
-                                else {
-                                    $this->plugin->getChatHandler()->removePlayerFromChat($sender);
-                                    $config->set("island", "");
-                                    $config->save();
-                                    $island->removeMember(strtolower($sender->getName()));
-                                    $this->sendMessage($sender, "You leave the island!!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to leave it!!");
-                            }
-                        }
-                        break;
-                    case "remove":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to leave it!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    if(isset($args[1])) {
-                                        if(in_array(strtolower($args[1]), $island->getMembers())) {
-                                            $island->removeMember(strtolower($args[1]));
-                                            $player = $this->plugin->getServer()->getPlayerExact($args[1]);
-                                            if($player instanceof Player and $player->isOnline()) {
-                                                $this->plugin->getChatHandler()->removePlayerFromChat($player);
-                                            }
-                                            $this->sendMessage($sender, "{$args[1]} was removed from your team!");
-                                        }
-                                        else {
-                                            $this->sendMessage($sender, "{$args[1]} isn't a player of your island!");
-                                        }
-                                    }
-                                    else {
-                                        $this->sendMessage($sender, "Usage: /skyblock remove <player>");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the island owner to do this!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to leave it!!");
-                            }
-                        }
-                        break;
-                    case "tp":
-                        if(isset($args[1])) {
-                            $island = $this->plugin->getIslandManager()->getIslandByOwner($args[1]);
-                            if($island instanceof Island) {
-                                if($island->isLocked()) {
-                                    $this->sendMessage($sender, "This island is locked, you cannot join it!");
-                                }
-                                else {
-                                    $sender->teleport(new Position(15, 7, 10, $this->plugin->getServer()->getLevelByName($island->getIdentifier())));
-                                    $this->sendMessage($sender, "You joined the island successfully");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "At least one island member must be active if you want see the island!");
-                            }
-                        }
-                        else {
-                            $this->sendMessage($sender, "Usage: /skyblock tp <owner name>");
-                        }
-                        break;
-                    case "reset":
-                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                        if(empty($config->get("island"))) {
-                            $this->sendMessage($sender, "You must be in a island to reset it!");
-                        }
-                        else {
-                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                            if($island instanceof Island) {
-                                if($island->getOwnerName() == strtolower($sender->getName())) {
-                                    $reset = $this->plugin->getResetHandler()->getResetTimer($sender);
-                                    if($reset instanceof Reset) {
-                                        $minutes = Utils::printSeconds($reset->getTime());
-                                        $this->sendMessage($sender, "You'll be able to reset your island again in {$minutes} minutes");
-                                    }
-                                    else {
-                                        foreach($island->getAllMembers() as $member) {
-                                            $memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
-                                            $memberConfig->set("island", "");
-                                            $memberConfig->save();
-                                        }
-                                        $generator = $island->getGenerator();
-                                        $this->plugin->getIslandManager()->removeIsland($island);
-                                        $this->plugin->getResetHandler()->addResetTimer($sender);
-                                        $this->plugin->getSkyBlockManager()->generateIsland($sender, $generator);
-                                        $this->sendMessage($sender, "You successfully reset the island!");
-                                    }
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be the owner to reset the island!");
-                                }
-                            }
-                            else {
-                                $this->sendMessage($sender, "You must be in a island to reset it!!");
-                            }
-                        }
-                        break;
-                    case "info":
-                        $commands = [
-                            "info" => "Show skyblock command info",
-                            "create" => "Create a new island",
-                            "join" => "Teleport you to your island",
-                            "expel" => "Kick someone from your island",
-                            "lock" => "Lock/unlock your island, then nobody/everybody will be able to join",
-                            "sethome" => "Set your island home",
-                            "home" => "Teleport you to your island home",
-                            "members" => "Show all members of your island",
-                            "tp <ownerName>" => "Teleport you to a island that isn't yours",
-                            "invite" => "Invite a player to be member of your island",
-                            "accept/reject <sender name>" => "Accept/reject an invitation",
-                            "leave" => "Leave your island",
-                            "remove" => "Remove your island",
-                            "makeleader" => "Transfer island ownership",
-                            "teamchat" => "Change your chat to your island chat"
-                        ];
-                        foreach($commands as $command => $description) {
-                            $sender->sendMessage(TextFormat::RED . "/skyblock {$command}: " . TextFormat::YELLOW . $description);
-                        }
-                        break;
-                    case "teamchat":
-                        if($this->plugin->getChatHandler()->isInChat($sender)) {
-                            $this->plugin->getChatHandler()->removePlayerFromChat($sender);
-                            $this->sendMessage($sender, "You successfully left your team chat!");
-                        }
-                        else {
-                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-                            if(empty($config->get("island"))) {
-                                $this->sendMessage($sender, "You must be in a island to use this command!");
-                            }
-                            else {
-                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-                                if($island instanceof Island) {
-                                    $this->plugin->getChatHandler()->addPlayerToChat($sender, $island);
-                                    $this->sendMessage($sender, "You joined your team chat room");
-                                }
-                                else {
-                                    $this->sendMessage($sender, "You must be in a island to use this command!!");
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        $this->sendMessage($sender, "Use /skyblock info if you don't know how to use the command!");
-                        break;
-                }
-            }
-            else {
-                $this->sendMessage($sender, "Use /skyblock info if you don't know how to use the command!");
-            }
-        }
-        else {
-            $sender->sendMessage("Please, run this command in game.");
-        }
-    }
+					case "kick":
+					case "expel":
+						if($sender->hasPermission('sbpe.cmd.kick') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										if(isset($args[1])){
+											$player = $this->plugin->getServer()->getPlayer($args[1]);
+											if($player instanceof Player and $player->isOnline()){
+												if($player->getLevel()->getName() == $island->getIdentifier()){
+													$player->teleport($this->plugin->getServer()->getDefaultLevel()->getSafeSpawn());
+													$this->sendMessage($sender, "{$player->getName()} §chas been kicked from your island!");
+												}else{
+													$this->sendMessage($sender, "§l§c✖§f §cThe player isn't in your island!");
+												}
+											}else{
+												$this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid player");
+											}
+										}else{
+											$this->sendMessage($sender, "§cUsage: /skyblock expel <name>");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to expel/kick anyone");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+								}
+							}
+						}
+						break;
+					case "lock":
+						if($sender->hasPermission('sbpe.cmd.lock') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										$island->setLocked(!$island->isLocked());
+										$locked = ($island->isLocked()) ? "locked" : "unlocked";
+										$this->sendMessage($sender, "§l§a✔§fYour island has been {$locked}!");
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou haven't got a island!");
+								}
+							}
+						}
+						break;
+					case "invite":
+						if($sender->hasPermission('sbpe.cmd.invite') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										if(isset($args[1])){
+											$player = $this->plugin->getServer()->getPlayer($args[1]);
+											if($player instanceof Player and $player->isOnline()){
+												$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
+												if(empty($config->get("island"))){
+													$this->plugin->getInvitationHandler()->addInvitation($sender, $player, $island);
+													$this->sendMessage($sender, "§l§a✔§fYou sent a invitation to §2{$player->getName()} §l§a✔§fsuccesfully!");
+													$this->sendMessage($player, "{$sender->getName()} §l§a✔§finvited you to his island! §2Do /skyblock <accept/reject> {$sender->getName()}");
+												}else{
+													$this->sendMessage($sender, "§l§c✖§f §cThis player is already in a island!");
+												}
+											}else{
+												$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a valid player!");
+											}
+										}else{
+											$this->sendMessage($sender, "§cUsage: /skyblock invite <player>");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+								}
+							}
+						}
+						break;
+					case "accept":
+						if($sender->hasPermission('sbpe.cmd.invite.accept') or $sender->hasPermission('sbpe')){
+							if(isset($args[1])){
+								$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+								if(empty($config->get("island"))){
+									$player = $this->plugin->getServer()->getPlayer($args[1]);
+									if($player instanceof Player and $player->isOnline()){
+										$invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
+										if($invitation !== null){
+											foreach($invitation as $invite){
+												if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()){
+													$invite->accept();
+												}
+											}
+										}else{
+											$this->sendMessage($sender, "§l§c✖§f §cYou don't have an invitation from {$player->getName()}");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want join another island!");
+								}
+							}else{
+								$this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
+							}
+						}
+						break;
+					case "deny":
+					case "reject":
+						if($sender->hasPermission('sbpe.cmd.invite.deny') or $sender->hasPermission('sbpe')){
+							if(isset($args[1])){
+								$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+								if(empty($config->get("island"))){
+									$player = $this->plugin->getServer()->getPlayer($args[1]);
+									if($player instanceof Player and $player->isOnline()){
+										$invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
+										if($invitation !== null){
+											foreach($invitation as $invite){
+												if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()){
+													$invite->deny();
+												}
+											}
+										}else{
+											$this->sendMessage($sender, "§l§c✖§f §cYou haven't got a invitation from {$player->getName()}");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want reject another island!");
+								}
+							}else{
+								$this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
+							}
+						}
+						break;
+					case "members":
+						if($sender->hasPermission('sbpe.cmd.members') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									$this->sendMessage($sender, "____| {$island->getOwnerName()}'s §l§a✔§fIsland Members |____");
+									$i = 1;
+									foreach($island->getAllMembers() as $member){
+										$this->sendMessage($sender, "{$i}. {$member}");
+										$i++;
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
+								}
+							}
+						}
+						break;
+					case "disband":
+						if($sender->hasPermission('sbpe.cmd.disband') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										foreach($island->getAllMembers() as $member){
+											$memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
+											$memberConfig->set("island", "");
+											$memberConfig->save();
+										}
+										$this->plugin->getIslandManager()->removeIsland($island);
+										$this->plugin->getResetHandler()->addResetTimer($sender);
+										$this->sendMessage($sender, "§l§a✔§fYou successfully deleted the island!");
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to disband the island!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
+								}
+							}
+						}
+						break;
+					case "leave":
+						if($sender->hasPermission('sbpe.cmd.leave') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										$this->sendMessage($sender, "§l§c✖§f §cYou cannot leave an island if you're the owner! Maybe you can try using /skyblock disband");
+									}else{
+										$sender->sendMessage("We Got There!");
+										$this->plugin->getChatHandler()->removePlayerFromChat($sender);
+										$config->set("island", "");
+										$config->save();
+										$island->removeMember(strtolower($sender->getName()));
+										$sender->teleport($sender->getServer()->getDefaultLevel()->getSafeSpawn());
+										$this->sendMessage($sender, "§l§a✔§fYou left the island successfully!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+								}
+							}
+						}
+						break;
+					case "remove":
+						if($sender->hasPermission('sbpe.cmd.remove') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										if(isset($args[1])){
+											if(in_array(strtolower($args[1]), $island->getMembers())){
+												$island->removeMember(strtolower($args[1]));
+												$config = Utils::getUserConfig($args[1]);
+												$config->set("island", "");
+												$config->save();
+												$player = $this->plugin->getServer()->getPlayerExact($args[1]);
+												if($player instanceof Player and $player->isOnline()){
+													$this->plugin->getChatHandler()->removePlayerFromChat($player);
+												}
+												$this->sendMessage($sender, "§2{$args[1]} §l§a✔§fwas removed from your team/island successfully!");
+											}else{
+												$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a player of your island!");
+											}
+										}else{
+											$this->sendMessage($sender, "§cUsage: /skyblock remove <player>");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+								}
+							}
+						}
+						break;
+					case "tp":
+						if($sender->hasPermission('sbpe.cmd.tp') or $sender->hasPermission('sbpe')){
+							if(isset($args[1])){
+								$island = $this->plugin->getIslandManager()->getIslandByOwner($args[1]);
+								if($island instanceof Island){
+									if($island->isLocked()){
+										$this->sendMessage($sender, "§l§c✖§f §cThis island is locked, you cannot join it!");
+									}else{
+										$safeSpawn = $this->plugin->getServer()->getLevelByName($island->getIdentifier())->getSafeSpawn();
+										$sender->teleport($safeSpawn);
+										$this->sendMessage($sender, "§l§a✔§fYou joined the island successfully");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cAt least one island member must be active if you want see the island!");
+								}
+							}else{
+								$this->sendMessage($sender, "§cUsage: /skyblock tp <owner name>");
+							}
+						}
+						break;
+					case "reset":
+						if($sender->hasPermission('sbpe.cmd.reset') or $sender->hasPermission('sbpe')){
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									if($island->getOwnerName() == strtolower($sender->getName())){
+										$reset = $this->plugin->getResetHandler()->getResetTimer($sender);
+										if($reset instanceof Reset){
+											$minutes = Utils::printSeconds($reset->getTime());
+											$this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to reset your island again in §d{$minutes} §l§l§a✔§f➡§fminutes");
+										}else{
+											foreach($island->getAllMembers() as $member){
+												$memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
+												$memberConfig->set("island", "");
+												$memberConfig->save();
+											}
+											$generator = $island->getGenerator();
+											$this->plugin->getIslandManager()->removeIsland($island);
+											$this->plugin->getResetHandler()->addResetTimer($sender);
+											$this->plugin->getSkyBlockManager()->generateIsland($sender, $generator);
+											$this->sendMessage($sender, "§l§a✔§fYou successfully reset the island!");
+										}
+									}else{
+										$this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to reset the island!");
+									}
+								}else{
+									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
+								}
+							}
+						}
+						break;
+					case "version":
+					case "ver":
+						if($sender->hasPermission('sbpe.cmd.ver') or $sender->hasPermission('sbpe')){
+							$this->sendMessage($sender, "§cNot showing infomation due to self-leak plugin.");
+						}
+						break;
+					case "help":
+						if($sender->hasPermission('sbpe.cmd.home') or $sender->hasPermission('sbpe')){
+							$commands = [
+								"§dhelp" => "§l§b➡§fShow skyblock command info",
+								"§dcreate" => "§l§b➡§fCreate a new island",
+								"§djoin" => "§l§b➡§fTeleport you to your island",
+								"§dexpel" => "§l§b➡§fKick someone from your island",
+								"§dlock" => "§l§b➡§fLock/unlock your island, then nobody/everybody will be able to join",
+								"§dsethome" => "§l§b➡§fSet your island home",
+								"§dhome" => "§l§b➡§fTeleport you to your island home",
+								"§dmembers" => "§l§b➡§fShow all members of your island",
+								"§dtp <ownerName>" => "§l§b➡§fTeleport you to an island that isn't yours",
+								"§dinvite" => "§l§b➡§fInvite a player to be member of your island",
+								"§daccept/reject <sender name>" => "§l§l§a✔§f➡§fAccept/reject an invitation",
+								"§dleave" => "§l§b➡§fLeave your island",
+								"§ddisband" => "§l§b➡§fDelete your island",
+								"§dteamchat" => "§l§b➡§fChange the style of chat on your island",
+								"§dremove" => "§l§b➡§fRemove a player from your island",
+								"§dreset" => "§l§b➡§fReset's your island.",
+								"§dversion" => "§l§b➡§fGets Skyblock version.",
 
+							];
+							$sender->sendMessage(TextFormat::DARK_GREEN . "-----------" . TextFormat::BOLD . TextFormat::AQUA . " [" . TextFormat::GREEN . "SkyBlockPE Help" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "-----------");
+							foreach($commands as $command => $description){
+
+								$sender->sendMessage(TextFormat::AQUA . "/" . TextFormat::GREEN . "island {$command}: " . TextFormat::RESET . TextFormat::DARK_GREEN . $description);
+							}
+						}
+						break;
+					case "teamchat":
+						if($this->plugin->getChatHandler()->isInChat($sender)){
+							$this->plugin->getChatHandler()->removePlayerFromChat($sender);
+							$this->sendMessage($sender, "You left the chat group successfully!");
+						}else{
+							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+							if(empty($config->get("island"))){
+								$this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
+							}else{
+								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+								if($island instanceof Island){
+									$this->plugin->getChatHandler()->addPlayerToChat($sender, $island);
+									$this->sendMessage($sender, "§a✔§fYou joined the chat group");
+								}else{
+									$this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
+								}
+							}
+						}
+						break;
+					default:
+						$this->sendMessage($sender, "§2Use /is help for a list of skyblock commands.");
+
+						break;
+				}
+			}else{
+				$this->sendMessage($sender, "§dUse §l§b➡§f/is help §dfor a list of skyblock commands.");
+			}
+		}else{
+			$sender->sendMessage("Please run this command in game, not via console.");
+		}
+	}
 }

--- a/src/SkyBlock/command/SkyBlockCommand.php
+++ b/src/SkyBlock/command/SkyBlockCommand.php
@@ -12,488 +12,549 @@ use SkyBlock\island\Island;
 use SkyBlock\SkyBlock;
 use SkyBlock\reset\Reset;
 
-class SkyBlockCommand extends Command{
-	/** @var SkyBlock */
-	private $plugin;
+class SkyBlockCommand extends Command {
+    /** @var SkyBlock */
+    private $plugin;
 
-	/**
-	 * SkyBlockCommand constructor.
-	 *
-	 * @param SkyBlock $plugin
-	 */
-	public function __construct(SkyBlock $plugin){
-		$this->plugin = $plugin;
-		parent::__construct("island", "SkyBlock command", "§cUsage: /skyblock", ["is"]);
-	}
+    /**
+     * SkyBlockCommand constructor.
+     *
+     * @param SkyBlock $plugin
+     */
+    public function __construct(SkyBlock $plugin) {
+        $this->plugin = $plugin;
+        parent::__construct("island", "SkyBlock command", "§cUsage: /skyblock", ["is"]);
+    }
 
-	public function sendMessage(Player $sender, $message){
-		$sender->sendMessage(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . $message);
-	}
+    public function sendMessage(Player $sender, $message) {
+        $sender->sendMessage(TextFormat::AQUA . TextFormat::BOLD . "[" . TextFormat::GREEN . "SkyBlockPE" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . $message);
+    }
 
-	public function execute(CommandSender $sender, string $commandLabel, array $args){
-		if($sender instanceof Player){
-			if(isset($args[0])){
-				switch($args[0]){
-					case "join":
-						if($sender->hasPermission('sbpe.cmd.join') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									$island->addPlayer($sender);
-									$level = $this->plugin->getServer()->getLevelByName($island->getIdentifier());
-									$spawnPoint = $level->getSpawnLocation();
-									$sender->teleport($spawnPoint);
-									$this->sendMessage($sender, "§l§a✔§fYou were teleported to your island home succesfully");
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!!");
-								}
-							}
-						}
-						break;
-					case "create":
-						if($sender->hasPermission('sbpe.cmd.create') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$reset = $this->plugin->getResetHandler()->getResetTimer($sender);
-								if($reset instanceof Reset){
-									$minutes = Utils::printSeconds($reset->getTime());
-									$this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to create a new island in §4{$minutes} §cminutes");
-								}else{
-									$skyBlockManager = $this->plugin->getSkyBlockGeneratorManager();
-									if(isset($args[1])){
-										if($skyBlockManager->isGenerator($args[1])){
-											$this->plugin->getSkyBlockManager()->generateIsland($sender, $args[1]);
-											$this->sendMessage($sender, "§l§a✔§fYou successfully created a {$skyBlockManager->getGeneratorIslandName($args[1])} island!");
-										}else{
-											$this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid SkyBlock generator!");
-										}
-									}else{
-										$this->plugin->getSkyBlockManager()->generateIsland($sender, "basic");
-										$this->sendMessage($sender, "§l§a✔§fYou successfully created a island!");
-										$this->plugin->getServer()->dispatchCommand($sender, "sb");
-									}
-								}
-							}else{
-								$this->sendMessage($sender, "§l§c✖§f §cYou already have a SkyBlock island!");
-							}
-						}
-						break;
-					case "home":
-						$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-						if(empty($config->get("island"))){
-							$this->sendMessage($sender, "§c✖§f You do not have an island!");
-						}else{
-							$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-							if($island instanceof Island){
-								$home = $island->getHomePosition();
-								if($home instanceof Position){
-									$sender->teleport($home);
-									$this->sendMessage($sender, "§a✔§f You have been teleported to your island home");
-								}else{
-									$this->sendMessage($sender, "§c➡§f Your island is not home yet!");
-								}
-							}else{
-								$this->sendMessage($sender, "§c✖§f You do not have an island!");
-							}
-						}
-						break;
-					case "sethome":
-						$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-						if(empty($config->get("island"))){
-							$this->sendMessage($sender, "§c✖§f You do not have an island!");
-						}else{
-							$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-							if($island instanceof Island){
-								if($island->getOwnerName() == strtolower($sender->getName())){
-									if($sender->getLevel()->getName() == $config->get("island")){
-										$island->setHomePosition($sender->getPosition());
-										$this->sendMessage($sender, "§a✔§f You have successfully set up your island home!");
-									}else{
-										$this->sendMessage($sender, "§c✖§f You have to stay in your island to set home!");
-									}
-								}else{
-									$this->sendMessage($sender, "§c➡§f You have to be the island's leader to do this!");
-								}
-							}else{
-								$this->sendMessage($sender, "§c✖§f You do not have an island!");
-							}
-						}
-						break;
+    public function execute(CommandSender $sender, string $commandLabel, array $args) {
+        if($sender instanceof Player) {
+            if(isset($args[0])) {
+                switch($args[0]){
+                    case "join":
+                        if($sender->hasPermission('sbpe.cmd.join') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    $island->addPlayer($sender);
+                                    $level = $this->plugin->getServer()->getLevelByName($island->getIdentifier());
+                                    $spawnPoint = $level->getSpawnLocation();
+                                    $sender->teleport($spawnPoint);
+                                    $this->sendMessage($sender, "§l§a✔§fYou were teleported to your island home succesfully");
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island!!");
+                                }
+                            }
+                        }
+                        break;
+                    case "create":
+                        if($sender->hasPermission('sbpe.cmd.create') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $reset = $this->plugin->getResetHandler()->getResetTimer($sender);
+                                if($reset instanceof Reset) {
+                                    $minutes = Utils::printSeconds($reset->getTime());
+                                    $this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to create a new island in §4{$minutes} §cminutes");
+                                }
+                                else {
+                                    $skyBlockManager = $this->plugin->getSkyBlockGeneratorManager();
+                                    if(isset($args[1])) {
+                                        if($skyBlockManager->isGenerator($args[1])) {
+                                            $this->plugin->getSkyBlockManager()->generateIsland($sender, $args[1]);
+                                            $this->sendMessage($sender, "§l§a✔§fYou successfully created a {$skyBlockManager->getGeneratorIslandName($args[1])} island!");
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid SkyBlock generator!");
+                                        }
+                                    }
+                                    else {
+                                        $this->plugin->getSkyBlockManager()->generateIsland($sender, "basic");
+                                        $this->sendMessage($sender, "§l§a✔§fYou successfully created a island!");
+                                        $this->plugin->getServer()->dispatchCommand($sender, "sb");
+                                    }
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou already have a SkyBlock island!");
+                            }
+                        }
+                        break;
+                    case "home":
+                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                        if(empty($config->get("island"))) {
+                            $this->sendMessage($sender, "§c✖§f You do not have an island!");
+                        }
+                        else {
+                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                            if($island instanceof Island) {
+                                $home = $island->getHomePosition();
+                                if($home instanceof Position) {
+                                    $sender->teleport($home);
+                                    $this->sendMessage($sender, "§a✔§f You have been teleported to your island home");
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§c➡§f Your island is not home yet!");
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§c✖§f You do not have an island!");
+                            }
+                        }
+                        break;
+                    case "sethome":
+                        $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                        if(empty($config->get("island"))) {
+                            $this->sendMessage($sender, "§c✖§f You do not have an island!");
+                        }
+                        else {
+                            $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                            if($island instanceof Island) {
+                                if($island->getOwnerName() == strtolower($sender->getName())) {
+                                    if($sender->getLevel()->getName() == $config->get("island")) {
+                                        $island->setHomePosition($sender->getPosition());
+                                        $this->sendMessage($sender, "§a✔§f You have successfully set up your island home!");
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§c✖§f You have to stay in your island to set home!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§c➡§f You have to be the island's leader to do this!");
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§c✖§f You do not have an island!");
+                            }
+                        }
+                        break;
 
-					case "kick":
-					case "expel":
-						if($sender->hasPermission('sbpe.cmd.kick') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										if(isset($args[1])){
-											$player = $this->plugin->getServer()->getPlayer($args[1]);
-											if($player instanceof Player and $player->isOnline()){
-												if($player->getLevel()->getName() == $island->getIdentifier()){
-													$player->teleport($this->plugin->getServer()->getDefaultLevel()->getSafeSpawn());
-													$this->sendMessage($sender, "{$player->getName()} §chas been kicked from your island!");
-												}else{
-													$this->sendMessage($sender, "§l§c✖§f §cThe player isn't in your island!");
-												}
-											}else{
-												$this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid player");
-											}
-										}else{
-											$this->sendMessage($sender, "§cUsage: /skyblock expel <name>");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to expel/kick anyone");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
-								}
-							}
-						}
-						break;
-					case "lock":
-						if($sender->hasPermission('sbpe.cmd.lock') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										$island->setLocked(!$island->isLocked());
-										$locked = ($island->isLocked()) ? "locked" : "unlocked";
-										$this->sendMessage($sender, "§l§a✔§fYour island has been {$locked}!");
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou haven't got a island!");
-								}
-							}
-						}
-						break;
-					case "invite":
-						if($sender->hasPermission('sbpe.cmd.invite') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										if(isset($args[1])){
-											$player = $this->plugin->getServer()->getPlayer($args[1]);
-											if($player instanceof Player and $player->isOnline()){
-												$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
-												if(empty($config->get("island"))){
-													$this->plugin->getInvitationHandler()->addInvitation($sender, $player, $island);
-													$this->sendMessage($sender, "§l§a✔§fYou sent a invitation to §2{$player->getName()} §l§a✔§fsuccesfully!");
-													$this->sendMessage($player, "{$sender->getName()} §l§a✔§finvited you to his island! §2Do /skyblock <accept/reject> {$sender->getName()}");
-												}else{
-													$this->sendMessage($sender, "§l§c✖§f §cThis player is already in a island!");
-												}
-											}else{
-												$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a valid player!");
-											}
-										}else{
-											$this->sendMessage($sender, "§cUsage: /skyblock invite <player>");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
-								}
-							}
-						}
-						break;
-					case "accept":
-						if($sender->hasPermission('sbpe.cmd.invite.accept') or $sender->hasPermission('sbpe')){
-							if(isset($args[1])){
-								$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-								if(empty($config->get("island"))){
-									$player = $this->plugin->getServer()->getPlayer($args[1]);
-									if($player instanceof Player and $player->isOnline()){
-										$invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
-										if($invitation !== null){
-											foreach($invitation as $invite){
-												if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()){
-													$invite->accept();
-												}
-											}
-										}else{
-											$this->sendMessage($sender, "§l§c✖§f §cYou don't have an invitation from {$player->getName()}");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want join another island!");
-								}
-							}else{
-								$this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
-							}
-						}
-						break;
-					case "deny":
-					case "reject":
-						if($sender->hasPermission('sbpe.cmd.invite.deny') or $sender->hasPermission('sbpe')){
-							if(isset($args[1])){
-								$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-								if(empty($config->get("island"))){
-									$player = $this->plugin->getServer()->getPlayer($args[1]);
-									if($player instanceof Player and $player->isOnline()){
-										$invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
-										if($invitation !== null){
-											foreach($invitation as $invite){
-												if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()){
-													$invite->deny();
-												}
-											}
-										}else{
-											$this->sendMessage($sender, "§l§c✖§f §cYou haven't got a invitation from {$player->getName()}");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want reject another island!");
-								}
-							}else{
-								$this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
-							}
-						}
-						break;
-					case "members":
-						if($sender->hasPermission('sbpe.cmd.members') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									$this->sendMessage($sender, "____| {$island->getOwnerName()}'s §l§a✔§fIsland Members |____");
-									$i = 1;
-									foreach($island->getAllMembers() as $member){
-										$this->sendMessage($sender, "{$i}. {$member}");
-										$i++;
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
-								}
-							}
-						}
-						break;
-					case "disband":
-						if($sender->hasPermission('sbpe.cmd.disband') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										foreach($island->getAllMembers() as $member){
-											$memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
-											$memberConfig->set("island", "");
-											$memberConfig->save();
-										}
-										$this->plugin->getIslandManager()->removeIsland($island);
-										$this->plugin->getResetHandler()->addResetTimer($sender);
-										$this->sendMessage($sender, "§l§a✔§fYou successfully deleted the island!");
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to disband the island!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
-								}
-							}
-						}
-						break;
-					case "leave":
-						if($sender->hasPermission('sbpe.cmd.leave') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										$this->sendMessage($sender, "§l§c✖§f §cYou cannot leave an island if you're the owner! Maybe you can try using /skyblock disband");
-									}else{
-										$sender->sendMessage("We Got There!");
-										$this->plugin->getChatHandler()->removePlayerFromChat($sender);
-										$config->set("island", "");
-										$config->save();
-										$island->removeMember(strtolower($sender->getName()));
-										$sender->teleport($sender->getServer()->getDefaultLevel()->getSafeSpawn());
-										$this->sendMessage($sender, "§l§a✔§fYou left the island successfully!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
-								}
-							}
-						}
-						break;
-					case "remove":
-						if($sender->hasPermission('sbpe.cmd.remove') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										if(isset($args[1])){
-											if(in_array(strtolower($args[1]), $island->getMembers())){
-												$island->removeMember(strtolower($args[1]));
-												$config = Utils::getUserConfig($args[1]);
-												$config->set("island", "");
-												$config->save();
-												$player = $this->plugin->getServer()->getPlayerExact($args[1]);
-												if($player instanceof Player and $player->isOnline()){
-													$this->plugin->getChatHandler()->removePlayerFromChat($player);
-												}
-												$this->sendMessage($sender, "§2{$args[1]} §l§a✔§fwas removed from your team/island successfully!");
-											}else{
-												$this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a player of your island!");
-											}
-										}else{
-											$this->sendMessage($sender, "§cUsage: /skyblock remove <player>");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
-								}
-							}
-						}
-						break;
-					case "tp":
-						if($sender->hasPermission('sbpe.cmd.tp') or $sender->hasPermission('sbpe')){
-							if(isset($args[1])){
-								$island = $this->plugin->getIslandManager()->getIslandByOwner($args[1]);
-								if($island instanceof Island){
-									if($island->isLocked()){
-										$this->sendMessage($sender, "§l§c✖§f §cThis island is locked, you cannot join it!");
-									}else{
-										$safeSpawn = $this->plugin->getServer()->getLevelByName($island->getIdentifier())->getSafeSpawn();
-										$sender->teleport($safeSpawn);
-										$this->sendMessage($sender, "§l§a✔§fYou joined the island successfully");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cAt least one island member must be active if you want see the island!");
-								}
-							}else{
-								$this->sendMessage($sender, "§cUsage: /skyblock tp <owner name>");
-							}
-						}
-						break;
-					case "reset":
-						if($sender->hasPermission('sbpe.cmd.reset') or $sender->hasPermission('sbpe')){
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									if($island->getOwnerName() == strtolower($sender->getName())){
-										$reset = $this->plugin->getResetHandler()->getResetTimer($sender);
-										if($reset instanceof Reset){
-											$minutes = Utils::printSeconds($reset->getTime());
-											$this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to reset your island again in §d{$minutes} §l§l§a✔§f➡§fminutes");
-										}else{
-											foreach($island->getAllMembers() as $member){
-												$memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
-												$memberConfig->set("island", "");
-												$memberConfig->save();
-											}
-											$generator = $island->getGenerator();
-											$this->plugin->getIslandManager()->removeIsland($island);
-											$this->plugin->getResetHandler()->addResetTimer($sender);
-											$this->plugin->getSkyBlockManager()->generateIsland($sender, $generator);
-											$this->sendMessage($sender, "§l§a✔§fYou successfully reset the island!");
-										}
-									}else{
-										$this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to reset the island!");
-									}
-								}else{
-									$this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
-								}
-							}
-						}
-						break;
-					case "version":
-					case "ver":
-						if($sender->hasPermission('sbpe.cmd.ver') or $sender->hasPermission('sbpe')){
-							$this->sendMessage($sender, "§cNot showing infomation due to self-leak plugin.");
-						}
-						break;
-					case "help":
-						if($sender->hasPermission('sbpe.cmd.home') or $sender->hasPermission('sbpe')){
-							$commands = [
-								"§dhelp" => "§l§b➡§fShow skyblock command info",
-								"§dcreate" => "§l§b➡§fCreate a new island",
-								"§djoin" => "§l§b➡§fTeleport you to your island",
-								"§dexpel" => "§l§b➡§fKick someone from your island",
-								"§dlock" => "§l§b➡§fLock/unlock your island, then nobody/everybody will be able to join",
-								"§dsethome" => "§l§b➡§fSet your island home",
-								"§dhome" => "§l§b➡§fTeleport you to your island home",
-								"§dmembers" => "§l§b➡§fShow all members of your island",
-								"§dtp <ownerName>" => "§l§b➡§fTeleport you to an island that isn't yours",
-								"§dinvite" => "§l§b➡§fInvite a player to be member of your island",
-								"§daccept/reject <sender name>" => "§l§l§a✔§f➡§fAccept/reject an invitation",
-								"§dleave" => "§l§b➡§fLeave your island",
-								"§ddisband" => "§l§b➡§fDelete your island",
-								"§dteamchat" => "§l§b➡§fChange the style of chat on your island",
-								"§dremove" => "§l§b➡§fRemove a player from your island",
-								"§dreset" => "§l§b➡§fReset's your island.",
-								"§dversion" => "§l§b➡§fGets Skyblock version.",
+                    case "kick":
+                    case "expel":
+                        if($sender->hasPermission('sbpe.cmd.kick') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        if(isset($args[1])) {
+                                            $player = $this->plugin->getServer()->getPlayer($args[1]);
+                                            if($player instanceof Player and $player->isOnline()) {
+                                                if($player->getLevel()->getName() == $island->getIdentifier()) {
+                                                    $player->teleport($this->plugin->getServer()->getDefaultLevel()->getSafeSpawn());
+                                                    $this->sendMessage($sender, "{$player->getName()} §chas been kicked from your island!");
+                                                }
+                                                else {
+                                                    $this->sendMessage($sender, "§l§c✖§f §cThe player isn't in your island!");
+                                                }
+                                            }
+                                            else {
+                                                $this->sendMessage($sender, "§l§c✖§f §cThat isn't a valid player");
+                                            }
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§cUsage: /skyblock expel <name>");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to expel/kick anyone");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+                                }
+                            }
+                        }
+                        break;
+                    case "lock":
+                        if($sender->hasPermission('sbpe.cmd.lock') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        $island->setLocked(!$island->isLocked());
+                                        $locked = ($island->isLocked()) ? "locked" : "unlocked";
+                                        $this->sendMessage($sender, "§l§a✔§fYour island has been {$locked}!");
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou haven't got a island!");
+                                }
+                            }
+                        }
+                        break;
+                    case "invite":
+                        if($sender->hasPermission('sbpe.cmd.invite') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        if(isset($args[1])) {
+                                            $player = $this->plugin->getServer()->getPlayer($args[1]);
+                                            if($player instanceof Player and $player->isOnline()) {
+                                                $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
+                                                if(empty($config->get("island"))) {
+                                                    $this->plugin->getInvitationHandler()->addInvitation($sender, $player, $island);
+                                                    $this->sendMessage($sender, "§l§a✔§fYou sent a invitation to §2{$player->getName()} §l§a✔§fsuccesfully!");
+                                                    $this->sendMessage($player, "{$sender->getName()} §l§a✔§finvited you to his island! §2Do /skyblock <accept/reject> {$sender->getName()}");
+                                                }
+                                                else {
+                                                    $this->sendMessage($sender, "§l§c✖§f §cThis player is already in a island!");
+                                                }
+                                            }
+                                            else {
+                                                $this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a valid player!");
+                                            }
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§cUsage: /skyblock invite <player>");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou Don't have an island");
+                                }
+                            }
+                        }
+                        break;
+                    case "accept":
+                        if($sender->hasPermission('sbpe.cmd.invite.accept') or $sender->hasPermission('sbpe')) {
+                            if(isset($args[1])) {
+                                $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                                if(empty($config->get("island"))) {
+                                    $player = $this->plugin->getServer()->getPlayer($args[1]);
+                                    if($player instanceof Player and $player->isOnline()) {
+                                        $invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
+                                        if($invitation !== null) {
+                                            foreach($invitation as $invite) {
+                                                if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()) {
+                                                    $invite->accept();
+                                                }
+                                            }
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§l§c✖§f §cYou don't have an invitation from {$player->getName()}");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want join another island!");
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
+                            }
+                        }
+                        break;
+                    case "deny":
+                    case "reject":
+                        if($sender->hasPermission('sbpe.cmd.invite.deny') or $sender->hasPermission('sbpe')) {
+                            if(isset($args[1])) {
+                                $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                                if(empty($config->get("island"))) {
+                                    $player = $this->plugin->getServer()->getPlayer($args[1]);
+                                    if($player instanceof Player and $player->isOnline()) {
+                                        $invitation = $this->plugin->getInvitationHandler()->getInvitationBySender($player);
+                                        if($invitation !== null) {
+                                            foreach($invitation as $invite) {
+                                                if($invite->getReceiver()->getUniqueId() === $sender->getUniqueId()) {
+                                                    $invite->deny();
+                                                }
+                                            }
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§l§c✖§f §cYou haven't got a invitation from {$player->getName()}");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §c{$args[1]} is not a valid player");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou cannot be in a island if you want reject another island!");
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§cUsage: /skyblock accept <sender name>");
+                            }
+                        }
+                        break;
+                    case "members":
+                        if($sender->hasPermission('sbpe.cmd.members') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    $this->sendMessage($sender, "____| {$island->getOwnerName()}'s §l§a✔§fIsland Members |____");
+                                    $i = 1;
+                                    foreach($island->getAllMembers() as $member) {
+                                        $this->sendMessage($sender, "{$i}. {$member}");
+                                        $i++;
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to use this command!");
+                                }
+                            }
+                        }
+                        break;
+                    case "disband":
+                        if($sender->hasPermission('sbpe.cmd.disband') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        foreach($island->getAllMembers() as $member) {
+                                            $memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
+                                            $memberConfig->set("island", "");
+                                            $memberConfig->save();
+                                        }
+                                        $this->plugin->getIslandManager()->removeIsland($island);
+                                        $this->plugin->getResetHandler()->addResetTimer($sender);
+                                        $this->sendMessage($sender, "§l§a✔§fYou successfully deleted the island!");
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to disband the island!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to disband it!");
+                                }
+                            }
+                        }
+                        break;
+                    case "leave":
+                        if($sender->hasPermission('sbpe.cmd.leave') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou cannot leave an island if you're the owner! Maybe you can try using /skyblock disband");
+                                    }
+                                    else {
+                                        $sender->sendMessage("We Got There!");
+                                        $this->plugin->getChatHandler()->removePlayerFromChat($sender);
+                                        $config->set("island", "");
+                                        $config->save();
+                                        $island->removeMember(strtolower($sender->getName()));
+                                        $sender->teleport($sender->getServer()->getDefaultLevel()->getSafeSpawn());
+                                        $this->sendMessage($sender, "§l§a✔§fYou left the island successfully!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+                                }
+                            }
+                        }
+                        break;
+                    case "remove":
+                        if($sender->hasPermission('sbpe.cmd.remove') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        if(isset($args[1])) {
+                                            if(in_array(strtolower($args[1]), $island->getMembers())) {
+                                                $island->removeMember(strtolower($args[1]));
+                                                $config = Utils::getUserConfig($args[1]);
+                                                $config->set("island", "");
+                                                $config->save();
+                                                $player = $this->plugin->getServer()->getPlayerExact($args[1]);
+                                                if($player instanceof Player and $player->isOnline()) {
+                                                    $this->plugin->getChatHandler()->removePlayerFromChat($player);
+                                                }
+                                                $this->sendMessage($sender, "§2{$args[1]} §l§a✔§fwas removed from your team/island successfully!");
+                                            }
+                                            else {
+                                                $this->sendMessage($sender, "§l§c✖§f §c{$args[1]} isn't a player of your island!");
+                                            }
+                                        }
+                                        else {
+                                            $this->sendMessage($sender, "§cUsage: /skyblock remove <player>");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the island owner to do this!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to leave it!");
+                                }
+                            }
+                        }
+                        break;
+                    case "tp":
+                        if($sender->hasPermission('sbpe.cmd.tp') or $sender->hasPermission('sbpe')) {
+                            if(isset($args[1])) {
+                                $island = $this->plugin->getIslandManager()->getIslandByOwner($args[1]);
+                                if($island instanceof Island) {
+                                    if($island->isLocked()) {
+                                        $this->sendMessage($sender, "§l§c✖§f §cThis island is locked, you cannot join it!");
+                                    }
+                                    else {
+                                        $safeSpawn = $this->plugin->getServer()->getLevelByName($island->getIdentifier())->getSafeSpawn();
+                                        $sender->teleport($safeSpawn);
+                                        $this->sendMessage($sender, "§l§a✔§fYou joined the island successfully");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cAt least one island member must be active if you want see the island!");
+                                }
+                            }
+                            else {
+                                $this->sendMessage($sender, "§cUsage: /skyblock tp <owner name>");
+                            }
+                        }
+                        break;
+                    case "reset":
+                        if($sender->hasPermission('sbpe.cmd.reset') or $sender->hasPermission('sbpe')) {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    if($island->getOwnerName() == strtolower($sender->getName())) {
+                                        $reset = $this->plugin->getResetHandler()->getResetTimer($sender);
+                                        if($reset instanceof Reset) {
+                                            $minutes = Utils::printSeconds($reset->getTime());
+                                            $this->sendMessage($sender, "§l§l§a✔§f➡§fYou'll be able to reset your island again in §d{$minutes} §l§l§a✔§f➡§fminutes");
+                                        }
+                                        else {
+                                            foreach($island->getAllMembers() as $member) {
+                                                $memberConfig = new Config($this->plugin->getDataFolder() . "users" . DIRECTORY_SEPARATOR . $member . ".json", Config::JSON);
+                                                $memberConfig->set("island", "");
+                                                $memberConfig->save();
+                                            }
+                                            $generator = $island->getGenerator();
+                                            $this->plugin->getIslandManager()->removeIsland($island);
+                                            $this->plugin->getResetHandler()->addResetTimer($sender);
+                                            $this->plugin->getSkyBlockManager()->generateIsland($sender, $generator);
+                                            $this->sendMessage($sender, "§l§a✔§fYou successfully reset the island!");
+                                        }
+                                    }
+                                    else {
+                                        $this->sendMessage($sender, "§l§c✖§f §cYou must be the owner to reset the island!");
+                                    }
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§l§c✖§f §cYou must be in a island to reset it!");
+                                }
+                            }
+                        }
+                        break;
+                    case "version":
+                    case "ver":
+                        if($sender->hasPermission('sbpe.cmd.ver') or $sender->hasPermission('sbpe')) {
+                            $this->sendMessage($sender, "§cNot showing infomation due to self-leak plugin.");
+                        }
+                        break;
+                    case "help":
+                        if($sender->hasPermission('sbpe.cmd.home') or $sender->hasPermission('sbpe')) {
+                            $commands = [
+                                "§dhelp" => "§l§b➡§fShow skyblock command info",
+                                "§dcreate" => "§l§b➡§fCreate a new island",
+                                "§djoin" => "§l§b➡§fTeleport you to your island",
+                                "§dexpel" => "§l§b➡§fKick someone from your island",
+                                "§dlock" => "§l§b➡§fLock/unlock your island, then nobody/everybody will be able to join",
+                                "§dsethome" => "§l§b➡§fSet your island home",
+                                "§dhome" => "§l§b➡§fTeleport you to your island home",
+                                "§dmembers" => "§l§b➡§fShow all members of your island",
+                                "§dtp <ownerName>" => "§l§b➡§fTeleport you to an island that isn't yours",
+                                "§dinvite" => "§l§b➡§fInvite a player to be member of your island",
+                                "§daccept/reject <sender name>" => "§l§l§a✔§f➡§fAccept/reject an invitation",
+                                "§dleave" => "§l§b➡§fLeave your island",
+                                "§ddisband" => "§l§b➡§fDelete your island",
+                                "§dteamchat" => "§l§b➡§fChange the style of chat on your island",
+                                "§dremove" => "§l§b➡§fRemove a player from your island",
+                                "§dreset" => "§l§b➡§fReset's your island.",
+                                "§dversion" => "§l§b➡§fGets Skyblock version.",
 
-							];
-							$sender->sendMessage(TextFormat::DARK_GREEN . "-----------" . TextFormat::BOLD . TextFormat::AQUA . " [" . TextFormat::GREEN . "SkyBlockPE Help" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "-----------");
-							foreach($commands as $command => $description){
+                            ];
+                            $sender->sendMessage(TextFormat::DARK_GREEN . "-----------" . TextFormat::BOLD . TextFormat::AQUA . " [" . TextFormat::GREEN . "SkyBlockPE Help" . TextFormat::AQUA . "] " . TextFormat::RESET . TextFormat::DARK_GREEN . "-----------");
+                            foreach($commands as $command => $description) {
 
-								$sender->sendMessage(TextFormat::AQUA . "/" . TextFormat::GREEN . "island {$command}: " . TextFormat::RESET . TextFormat::DARK_GREEN . $description);
-							}
-						}
-						break;
-					case "teamchat":
-						if($this->plugin->getChatHandler()->isInChat($sender)){
-							$this->plugin->getChatHandler()->removePlayerFromChat($sender);
-							$this->sendMessage($sender, "You left the chat group successfully!");
-						}else{
-							$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
-							if(empty($config->get("island"))){
-								$this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
-							}else{
-								$island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
-								if($island instanceof Island){
-									$this->plugin->getChatHandler()->addPlayerToChat($sender, $island);
-									$this->sendMessage($sender, "§a✔§fYou joined the chat group");
-								}else{
-									$this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
-								}
-							}
-						}
-						break;
-					default:
-						$this->sendMessage($sender, "§2Use /is help for a list of skyblock commands.");
+                                $sender->sendMessage(TextFormat::AQUA . "/" . TextFormat::GREEN . "island {$command}: " . TextFormat::RESET . TextFormat::DARK_GREEN . $description);
+                            }
+                        }
+                        break;
+                    case "teamchat":
+                        if($this->plugin->getChatHandler()->isInChat($sender)) {
+                            $this->plugin->getChatHandler()->removePlayerFromChat($sender);
+                            $this->sendMessage($sender, "You left the chat group successfully!");
+                        }
+                        else {
+                            $config = $this->plugin->getSkyBlockManager()->getPlayerConfig($sender);
+                            if(empty($config->get("island"))) {
+                                $this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
+                            }
+                            else {
+                                $island = $this->plugin->getIslandManager()->getOnlineIsland($config->get("island"));
+                                if($island instanceof Island) {
+                                    $this->plugin->getChatHandler()->addPlayerToChat($sender, $island);
+                                    $this->sendMessage($sender, "§a✔§fYou joined the chat group");
+                                }
+                                else {
+                                    $this->sendMessage($sender, "§c➡§f You must be in an island to use this command!");
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        $this->sendMessage($sender, "§2Use /is help for a list of skyblock commands.");
 
-						break;
-				}
-			}else{
-				$this->sendMessage($sender, "§dUse §l§b➡§f/is help §dfor a list of skyblock commands.");
-			}
-		}else{
-			$sender->sendMessage("Please run this command in game, not via console.");
-		}
-	}
+                        break;
+                }
+            }
+            else {
+                $this->sendMessage($sender, "§dUse §l§b➡§f/is help §dfor a list of skyblock commands.");
+            }
+        }
+        else {
+            $sender->sendMessage("Please run this command in game, not via console.");
+        }
+    }
 }

--- a/src/SkyBlock/command/SkyBlockUICommand.php
+++ b/src/SkyBlock/command/SkyBlockUICommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SkyBlock\command;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\Player;
+use SkyBlock\island\IslandManager;
+use SkyBlock\SkyBlock;
+use SkyBlock\ui\SkyBlockForms;
+
+class SkyBlockUICommand extends Command{
+
+	/**
+	 * @var IslandManager
+	 */
+	private $islandManager;
+
+	/** @var SkyBlock */
+	private $plugin;
+
+	/** @var SkyBlockForms */
+	private $ui;
+
+	/**
+	 * SkyBlockCommand constructor.
+	 *
+	 * @param SkyBlock $plugin
+	 */
+	public function __construct(SkyBlock $plugin){
+		$this->plugin = $plugin;
+		$this->islandManager = $plugin->getIslandManager();
+		$this->ui = $plugin->getUserInterface();
+		parent::__construct("skyblock", "SkyBlock SkyBlock command", "§cUsage: /sb", ["sb"]);
+	}
+
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
+		if($sender instanceof Player){
+			if(empty($args)){
+				$onIsland = false;
+				foreach($this->islandManager->getOnlineIslands() as $testIsland){
+					if($testIsland->isOnIsland($sender)){
+						$onIsland = true;
+						$island = $testIsland;
+						$islandOwner = strtolower($island->getOwnerName());
+						break;
+					}
+				}
+				if($onIsland){
+					$playerName = strtolower($sender->getName());
+					if(strcmp($playerName, $islandOwner) === 0){
+						$this->ui->ownerUI($sender);
+						return;
+					}
+					if($island->isMember($sender)){
+						$this->ui->memberUI($sender);
+						return;
+					}
+				}
+				$this->ui->guestUI($sender);
+				return;
+			}
+		}else{
+			$sender->sendMessage("Please run this command in game, not via console.");
+		}
+		return;
+	}
+}

--- a/src/SkyBlock/generator/SkyBlockGeneratorManager.php
+++ b/src/SkyBlock/generator/SkyBlockGeneratorManager.php
@@ -2,7 +2,7 @@
 
 namespace SkyBlock\generator;
 
-use pocketmine\level\generator\Generator;
+use pocketmine\level\generator\GeneratorManager;
 use SkyBlock\generator\generators\BasicIsland;
 use SkyBlock\SkyBlock;
 
@@ -22,7 +22,7 @@ class SkyBlockGeneratorManager {
     public function __construct(SkyBlock $plugin) {
         $this->plugin = $plugin;
         $this->registerGenerator(BasicIsland::class, "basic", "Basic Island");
-        Generator::addGenerator(BasicIsland::class, "basicgen");
+        GeneratorManager::addGenerator(BasicIsland::class, "basicgen");
     }
 
     /**
@@ -56,7 +56,7 @@ class SkyBlockGeneratorManager {
      * @param string $islandName
      */
     public function registerGenerator($generator, $name, $islandName) {
-        Generator::addGenerator($generator, $name);
+        GeneratorManager::addGenerator($generator, $name);
         $this->generators[$name] = $islandName;
     }
 

--- a/src/SkyBlock/generator/SkyBlockGeneratorManager.php
+++ b/src/SkyBlock/generator/SkyBlockGeneratorManager.php
@@ -11,7 +11,7 @@ class SkyBlockGeneratorManager {
     /** @var SkyBlock */
     private $plugin;
 
-    /** @var SkyBlockGenerator[] */
+    /** @var string[] */
     private $generators = [];
 
     /**

--- a/src/SkyBlock/generator/generators/BasicIsland.php
+++ b/src/SkyBlock/generator/generators/BasicIsland.php
@@ -3,6 +3,7 @@
 namespace SkyBlock\generator\generators;
 
 use pocketmine\block\Block;
+use pocketmine\block\BlockIds;
 use pocketmine\level\ChunkManager;
 use pocketmine\level\generator\object\Tree;
 use pocketmine\math\Vector3;
@@ -50,42 +51,55 @@ class BasicIsland extends SkyBlockGenerator {
      *
      * @return string
      */
-    public function getName() : string {
+    public function getName(): string {
         return $this->name;
     }
 
-    public function getSettings() : array {
+    public function getSettings(): array {
         return $this->settings;
     }
 
     public function generateChunk(int $chunkX, int $chunkZ) {
         $chunk = $this->level->getChunk($chunkX, $chunkZ);
         $chunk->setGenerated();
-        if ($chunkX == 0 and $chunkZ == 0) {
-            for ($x = 0; $x < 16; $x++) {
-                for ($z = 0; $z < 16; $z++) {
-                    $chunk->setBlock($x, 0, $z, Block::BEDROCK);
-                    for ($y = 1; $y <= 3; $y++) {
-                        $chunk->setBlock($x, $y, $z, Block::STONE);
-                    }
-                    $chunk->setBlock($x, 4, $z, Block::DIRT);
-                    $chunk->setBlock($x, 5, $z, Block::GRASS);
+        //SkyBlock Island
+        if ($chunkX == 0 && $chunkZ == 0) {
+            for ($x = 6; $x < 12; $x++) {
+                for ($z = 6; $z < 12; $z++) {
+					$chunk->setBlock($x, 61, $z, Block::DIRT);
+                    $chunk->setBlock($x, 62, $z, Block::DIRT);
+                    $chunk->setBlock($x, 63, $z, Block::GRASS);
                 }
-                Tree::growTree($this->level, $chunkX * 16 + 8, 6, $chunkZ * 16 + 8, $this->random, 0);
             }
+            for($airX = 9; $airX < 12; $airX++){
+            	for($airZ = 9; $airZ < 12; $airZ++) {
+					$chunk->setBlock($airX, 61, $airZ, Block::AIR);
+					$chunk->setBlock($airX, 62, $airZ, Block::AIR);
+					$chunk->setBlock($airX, 63, $airZ, Block::AIR);
+				}
+			}
+			Tree::growTree($this->level, $chunkX * 16 + 11 , 64, $chunkZ * 16 + 6, $this->random, 0);
             $chunk->setX($chunkX);
             $chunk->setZ($chunkZ);
             $this->level->setChunk($chunkX, $chunkZ, $chunk);
         }
+
+        // Sand Island
+		if($chunkX == 4 and $chunkZ == 0) {
+        	for($x = 6; $x < 11; $x++){
+        		for($z = 6; $z < 11; $z++) {
+        			for($y = 60; $y < 65; $y++){
+						$chunk->setBlock($x, $y, $z, Block::SAND);
+					}
+				}
+			}
+			$chunk->setBlock(8, 65, 8, BlockIds::CACTUS);
+		}
     }
 
     public function populateChunk(int $chunkX, int $chunkZ) {
-        // this disappeared in API 3.0.0-ALPHA1 due to client changes (client doesn't support custom biome colours anymore)
-        /*for ($x = 0; $x < 16; $x++) {
-            for ($z = 0; $z < 16; $z++) {
-                $this->level->getChunk($chunkX, $chunkZ)->setBiomeColor($x, $z, 133, 188, 86);
-            }
-        }*/
+        //TODO: Set Biome ID?
+        return;
     }
 
     /**
@@ -93,8 +107,8 @@ class BasicIsland extends SkyBlockGenerator {
      *
      * @return Vector3
      */
-    public function getSpawn() : Vector3 {
-        return new Vector3(8, 7, 10);
+    public function getSpawn(): Vector3{
+        return new Vector3(7, 66, 7);
     }
 
 }

--- a/src/SkyBlock/generator/generators/BasicIsland.php
+++ b/src/SkyBlock/generator/generators/BasicIsland.php
@@ -19,10 +19,10 @@ class BasicIsland extends SkyBlockGenerator {
     private $name;
 
     /** @var ChunkManager */
-    private $level;
+    protected $level;
 
     /** @var Random */
-    private $random;
+    protected $random;
 
     /**
      * BasicIsland constructor.
@@ -39,7 +39,7 @@ class BasicIsland extends SkyBlockGenerator {
      * @param ChunkManager $level
      * @param Random $random
      */
-    public function init(ChunkManager $level, Random $random) {
+	public function init(ChunkManager $level, Random $random) : void{
         $this->level = $level;
         $this->random = $random;
         $this->name = "basic";
@@ -59,7 +59,7 @@ class BasicIsland extends SkyBlockGenerator {
         return $this->settings;
     }
 
-    public function generateChunk(int $chunkX, int $chunkZ) {
+    public function generateChunk(int $chunkX, int $chunkZ) : void {
         $chunk = $this->level->getChunk($chunkX, $chunkZ);
         $chunk->setGenerated();
         //SkyBlock Island
@@ -97,7 +97,7 @@ class BasicIsland extends SkyBlockGenerator {
 		}
     }
 
-    public function populateChunk(int $chunkX, int $chunkZ) {
+    public function populateChunk(int $chunkX, int $chunkZ) : void {
         //TODO: Set Biome ID?
         return;
     }

--- a/src/SkyBlock/generator/generators/OPIsland.php
+++ b/src/SkyBlock/generator/generators/OPIsland.php
@@ -18,10 +18,10 @@ class OPIsland extends SkyBlockGenerator {
 	private $name;
 
 	/** @var ChunkManager */
-	private $level;
+	protected $level;
 
 	/** @var Random */
-	private $random;
+	protected $random;
 
 	/**
 	 * BasicIsland constructor.
@@ -38,7 +38,7 @@ class OPIsland extends SkyBlockGenerator {
 	 * @param ChunkManager $level
 	 * @param Random $random
 	 */
-	public function init(ChunkManager $level, Random $random) {
+	public function init(ChunkManager $level, Random $random) : void{
 		$this->level = $level;
 		$this->random = $random;
 		$this->name = "basic";
@@ -58,7 +58,7 @@ class OPIsland extends SkyBlockGenerator {
 		return $this->settings;
 	}
 
-	public function generateChunk(int $chunkX, int $chunkZ) {
+	public function generateChunk(int $chunkX, int $chunkZ) : void {
 		$chunk = $this->level->getChunk($chunkX, $chunkZ);
 		$chunk->setGenerated();
 		if ($chunkX == 0 && $chunkZ == 0) {
@@ -79,7 +79,7 @@ class OPIsland extends SkyBlockGenerator {
 		}
 	}
 
-	public function populateChunk(int $chunkX, int $chunkZ) {
+	public function populateChunk(int $chunkX, int $chunkZ) : void {
 		//TODO: Set Biome ID?
 		return;
 	}

--- a/src/SkyBlock/generator/generators/OPIsland.php
+++ b/src/SkyBlock/generator/generators/OPIsland.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SkyBlock\generator\generators;
+
+use pocketmine\block\Block;
+use pocketmine\level\ChunkManager;
+use pocketmine\level\generator\object\Tree;
+use pocketmine\math\Vector3;
+use pocketmine\utils\Random;
+use SkyBlock\generator\SkyBlockGenerator;
+
+class OPIsland extends SkyBlockGenerator {
+
+	/** @var array */
+	private $settings;
+
+	/** @var string */
+	private $name;
+
+	/** @var ChunkManager */
+	private $level;
+
+	/** @var Random */
+	private $random;
+
+	/**
+	 * BasicIsland constructor.
+	 *
+	 * @param array $settings
+	 */
+	public function __construct(array $settings = []) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Initialize BasicIsland
+	 *
+	 * @param ChunkManager $level
+	 * @param Random $random
+	 */
+	public function init(ChunkManager $level, Random $random) {
+		$this->level = $level;
+		$this->random = $random;
+		$this->name = "basic";
+		$this->islandName = "Basic Island";
+	}
+
+	/**
+	 * Return generator name
+	 *
+	 * @return string
+	 */
+	public function getName(): string {
+		return $this->name;
+	}
+
+	public function getSettings(): array {
+		return $this->settings;
+	}
+
+	public function generateChunk(int $chunkX, int $chunkZ) {
+		$chunk = $this->level->getChunk($chunkX, $chunkZ);
+		$chunk->setGenerated();
+		if ($chunkX == 0 && $chunkZ == 0) {
+			for ($x = 0; $x < 16; $x++) {
+				for ($z = 0; $z < 16; $z++) {
+					$chunk->setBlock($x, 0, $z, Block::BEDROCK);
+					for ($y = 1; $y <= 3; $y++) {
+						$chunk->setBlock($x, $y, $z, Block::STONE);
+					}
+					$chunk->setBlock($x, 4, $z, Block::DIRT);
+					$chunk->setBlock($x, 5, $z, Block::GRASS);
+				}
+				Tree::growTree($this->level, $chunkX * 16 + 8, 6, $chunkZ * 16 + 8, $this->random, 0);
+			}
+			$chunk->setX($chunkX);
+			$chunk->setZ($chunkZ);
+			$this->level->setChunk($chunkX, $chunkZ, $chunk);
+		}
+	}
+
+	public function populateChunk(int $chunkX, int $chunkZ) {
+		//TODO: Set Biome ID?
+		return;
+	}
+
+	/**
+	 * Return BasicIsland spawn
+	 *
+	 * @return Vector3
+	 */
+	public function getSpawn(): Vector3{
+		return new Vector3(8, 7, 10);
+	}
+
+}

--- a/src/SkyBlock/invitation/InvitationHandler.php
+++ b/src/SkyBlock/invitation/InvitationHandler.php
@@ -24,7 +24,7 @@ class InvitationHandler {
     }
 
     /**
-     * Return Main instance
+     * Return SkyBlockPE instance
      *
      * @return SkyBlock
      */
@@ -42,19 +42,43 @@ class InvitationHandler {
     }
 
     /**
-     * Return an invitation
+     * Returns an array of invitations based on the sender of the invitation.
      *
-     * @param Player $player
-     * @return null|Invitation
+     * @param Player $sender
+     * @return null|Invitation[]
      */
-    public function getInvitation(Player $player) {
-        if(isset($this->invitations[strtolower($player->getName())])) {
-            return $this->invitations[strtolower($player->getName())];
-        }
-        else {
-            return null;
-        }
+    public function getInvitationBySender(Player $sender) {
+    	$invitations = [];
+    	foreach($this->invitations as $invite){
+    		if($invite->getSender()->getUniqueId() === $sender->getUniqueId()){
+    			$invitations[] = $invite;
+			}
+		}
+		if(empty($invitations)){
+    		return null;
+		}
+		return $invitations;
     }
+
+	/**
+	 * Returns an array of invitations based on the receiver of the invitation.
+	 *
+	 * @param Player $receiver
+	 * @return null|Invitation[]
+	 */
+
+    public function getInvitationByReceiver(Player $receiver) {
+		$invitations = [];
+		foreach($this->invitations as $invite){
+			if($invite->getReceiver()->getUniqueId() === $receiver->getUniqueId()){
+				$invitations[] = $invite;
+			}
+		}
+		if(empty($invitations)){
+			return null;
+		}
+		return $invitations;
+	}
 
     /**
      * Create a new invitation
@@ -64,7 +88,7 @@ class InvitationHandler {
      * @param Island $island
      */
     public function addInvitation(Player $sender, Player $receiver, Island $island) {
-        $this->invitations[strtolower($sender->getName())] = new Invitation($this, $sender, $receiver, $island);
+        $this->invitations[] = new Invitation($this, $sender, $receiver, $island);
     }
 
     /**

--- a/src/SkyBlock/island/Island.php
+++ b/src/SkyBlock/island/Island.php
@@ -5,6 +5,7 @@ namespace SkyBlock\island;
 
 use pocketmine\level\Position;
 use pocketmine\Player;
+use pocketmine\Server;
 use pocketmine\utils\Config;
 use SkyBlock\Utils;
 
@@ -81,6 +82,44 @@ class Island {
     public function getIdentifier() {
         return $this->identifier;
     }
+
+	/**
+	 * Returns true if player is currently on this island.
+	 *
+	 * @param Player $player
+	 * @return bool
+	 */
+
+    public function isOnIsland(Player $player): bool{
+		$playerName = strtolower($player->getName());
+    	foreach($this->playersOnline as $key => $testPlayer){
+			if($testPlayer instanceof Player){
+				$testName = strtolower($testPlayer->getName());
+				if($testName === $playerName){
+					return true;
+				}
+			} else {
+				Server::getInstance()->getLogger()->error("[SkyBlock] isOnIsland: found non-Player object in online player table.");
+				var_dump($testPlayer);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns true if Player is a member of this island.
+	 *
+	 * @param Player $player
+	 * @return bool
+	 */
+	public function isMember(Player $player): bool {
+    	foreach($this->members as $member){
+    		if(strtolower($player->getName()) === $member){
+    			return true;
+			}
+		}
+		return false;
+	}
 
     /**
      * Return island online players
@@ -162,7 +201,9 @@ class Island {
      * @param Player $player
      */
     public function addPlayer(Player $player) {
-        $this->playersOnline[] = $player;
+    	if(!$this->isOnIsland($player)){
+			$this->playersOnline[] = $player;
+		}
     }
 
     /**
@@ -262,8 +303,15 @@ class Island {
      */
     public function tryRemovePlayer(Player $player) {
         if(in_array($player, $this->playersOnline)) {
-            unset($this->playersOnline[array_search($player, $this->playersOnline)]);
-        }
+        	$key = array_search($player, $this->playersOnline);
+            unset($this->playersOnline[$key]);
+        }else{
+        	foreach($this->playersOnline as $key => $onlinePlayer){
+        		if($onlinePlayer->getId() === $player->getId()){
+        			unset($this->playersOnline[$key]);
+				}
+			}
+		}
     }
 
     /**

--- a/src/SkyBlock/skyblock/SkyBlockManager.php
+++ b/src/SkyBlock/skyblock/SkyBlockManager.php
@@ -4,7 +4,7 @@ namespace SkyBlock\skyblock;
 
 use pocketmine\block\Block;
 use pocketmine\item\Item;
-use pocketmine\level\generator\Generator;
+use pocketmine\level\generator\GeneratorManager;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
 use pocketmine\tile\Chest;
@@ -33,7 +33,7 @@ class SkyBlockManager {
         $this->plugin->getIslandManager()->createIsland($player, $generatorName);
         $server = $this->plugin->getServer();
         $island = $this->getPlayerConfig($player)->get("island");
-        $server->generateLevel($island, null, Generator::getGenerator($generatorName));
+        $server->generateLevel($island, null, GeneratorManager::getGenerator($generatorName));
         $server->loadLevel($island);
         $this->spawnDefaultChest($island);
         $level = $server->getLevelByName($island);

--- a/src/SkyBlock/skyblock/SkyBlockManager.php
+++ b/src/SkyBlock/skyblock/SkyBlockManager.php
@@ -6,11 +6,6 @@ use pocketmine\block\Block;
 use pocketmine\item\Item;
 use pocketmine\level\generator\Generator;
 use pocketmine\math\Vector3;
-use pocketmine\nbt\NBT;
-use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\ListTag;
-use pocketmine\nbt\tag\StringTag;
 use pocketmine\Player;
 use pocketmine\tile\Chest;
 use pocketmine\tile\Tile;
@@ -38,39 +33,33 @@ class SkyBlockManager {
         $server->generateLevel($island, null, Generator::getGenerator($generatorName));
         $server->loadLevel($island);
         $this->spawnDefaultChest($island);
+        $level = $server->getLevelByName($island);
+        $level->setSpawnLocation(new Vector3(7,64,9));
     }
 
     public function spawnDefaultChest($islandName) {
+    	$chestX = 7;
+    	$chestY = 64;
+    	$chestZ = 6;
+    	$chestVector = new Vector3($chestX, $chestY, $chestZ);
         $level = $this->plugin->getServer()->getLevelByName($islandName);
-        $level->setBlock(new Vector3(10, 6, 4), new Block(0, 0));
+        $level->setBlock($chestVector, new Block(0, 0));
         $level->loadChunk(10, 4, true);
-        $level->setBlock(new Vector3(10, 6, 4), new Block(54, 0));
         /** @var Chest $chest */
-        $nbt = new CompoundTag(" ", [
-            new ListTag("Items", []),
-            new StringTag("id", Tile::CHEST),
-            new IntTag("x", 10),
-            new IntTag("y", 6),
-            new IntTag("z", 4)
-        ]);
-        $nbt->getListTag("Items")->setTagType(NBT::TAG_Compound);
-        $chest = Tile::createTile("Chest", $level, $nbt);
-        $level->addTile($chest);
+		$nbt = Chest::createNBT($chestVector);
+        $chest = Tile::createTile(Tile::CHEST, $level, $nbt);
         $inventory = $chest->getInventory();
-        $inventory->addItem(Item::get(Item::WATER, 0, 2));
-        $inventory->addItem(Item::get(Item::LAVA, 0, 1));
+        //TODO: Use a kit config for user-friendliness.
+        $inventory->addItem(Item::get(Item::BUCKET, 10, 1));
         $inventory->addItem(Item::get(Item::ICE, 0, 2));
         $inventory->addItem(Item::get(Item::MELON_BLOCK, 0, 1));
         $inventory->addItem(Item::get(Item::BONE, 0, 1));
         $inventory->addItem(Item::get(Item::PUMPKIN_SEEDS, 0, 1));
-        $inventory->addItem(Item::get(Item::CACTUS, 0, 1));
-        $inventory->addItem(Item::get(Item::SUGARCANE, 0, 1));
+        //$inventory->addItem(Item::get(Item::CACTUS, 0, 1));
+        $inventory->addItem(Item::get(Item::SUGARCANE_BLOCK, 0, 1));
         $inventory->addItem(Item::get(Item::BREAD, 0, 1));
         $inventory->addItem(Item::get(Item::WHEAT, 0, 1));
-        $inventory->addItem(Item::get(Item::LEATHER_BOOTS, 0, 1));
-        $inventory->addItem(Item::get(Item::LEATHER_PANTS, 0, 1));
-        $inventory->addItem(Item::get(Item::LEATHER_TUNIC, 0, 1));
-        $inventory->addItem(Item::get(Item::LEATHER_CAP, 0, 1));
+		$level->setBlock($chestVector, new Block(54, 3));
     }
 
     /**

--- a/src/SkyBlock/ui/SkyBlockForms.php
+++ b/src/SkyBlock/ui/SkyBlockForms.php
@@ -1,0 +1,518 @@
+<?php
+
+
+namespace SkyBlock\ui;
+
+
+use jojoe77777\FormAPI\FormAPI;
+use pocketmine\Player;
+use pocketmine\Server;
+use SkyBlock\invitation\Invitation;
+use SkyBlock\invitation\InvitationHandler;
+use SkyBlock\island\Island;
+use SkyBlock\island\IslandManager;
+use SkyBlock\SkyBlock;
+use SkyBlock\Utils;
+
+class SkyBlockForms{
+
+	const COMMAND_NAME = "is ";
+	const BASE_TITLE = "§l§3Sky§4Block";
+
+	/** @var FormAPI */
+	private $formAPI;
+
+	/** @var IslandManager */
+	private $islandManager;
+
+	/** @var InvitationHandler */
+	private $invitationHandler;
+
+	/** @var Invitation[] */
+	private $invitationPass;
+
+	/**	@var string[] */
+	private $ownerPass;
+
+	/** @var SkyBlock */
+	private $plugin;
+
+	public function __construct(){
+		$this->plugin = SkyBlock::getInstance();
+		$this->formAPI = Server::getInstance()->getPluginManager()->getPlugin("FormAPI");
+		$this->invitationHandler = $this->plugin->getInvitationHandler();
+		$this->islandManager = $this->plugin->getIslandManager();
+	}
+
+	public function sendMessage(Player $sender, $message){
+		$sender->sendMessage("§b§l[§aSkyBlockPE§b] §r§2" . $message);
+	}
+
+	public function ownerUI(Player $player){
+		$form = $this->formAPI->createSimpleForm([$this, "handleOwnerUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Owner SkyBlock");
+		$form->addButton("§1Go Home",-1,"","home");
+		if($this->islandManager->getIslandByOwner($player->getName())->isLocked()){
+			$form->addButton("§1Unlock this Island",-1,"","lock");
+		} else {
+			$form->addButton("§1Lock this Island",-1,"","lock");
+		}
+		$form->addButton("§1Invite",-1,"","invite");
+		$form->addButton("§1Kick",-1,"","kick");
+		$form->addButton("§1Manage",-1,"","manage");
+		$form->addButton("§1Go to Spawn",-1,"","spawn");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleOwnerUI(Player $player, $data){
+		$result = $data;
+		if($result == null){
+			return;
+		}
+		switch($result){
+			case "home": $command = "home";
+				break;
+			case "lock": $command = "lock";
+				break;
+			case "kick": $this->kickUI($player);
+				return;
+			case "invite": $this->inviteUI($player);
+				return;
+			case "manage": $this->manageUI($player);
+				return;
+			case "spawn": $this->sendToSpawn($player);
+				return;
+			default: $this->handleSwitchError($player, "handleOwnerUI", $result);
+				return;
+		}
+		$command = self::COMMAND_NAME . $command;
+		$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		return;
+	}
+
+	public function memberUI(Player $player){
+		$form = $this->formAPI->createSimpleForm([$this, "handleMemberUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Member SkyBlock");
+		$form->addButton("§1Go Home",-1,"","home");
+		$form->addButton("§1Leave",-1,"","leave");
+		$form->addButton("§1Go to Spawn",-1,"","spawn");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleMemberUI(Player $player, $data){
+		$result = $data;
+		if($result === null){
+			return;
+		}
+		switch($result){
+			case "home": $command = "home";
+				break;
+
+			case "leave": $this->leaveUI($player);
+				return;
+
+			case "spawn": $this->sendToSpawn($player);
+				return;
+
+			default: $this->handleSwitchError($player, "handleMemberUI", $result);
+				return;
+		}
+		$command = self::COMMAND_NAME . $command;
+		$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		return;
+	}
+
+	public function guestUI(Player $player){
+		$form = $this->formAPI->createSimpleForm([$this, "handleGuestUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - SkyBlock");
+		$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($player);
+		if(empty($config->get("island"))){
+			$form->addButton("§1Create an Island",-1,"","create");
+		} else {
+			$form->addButton("§1Go to your Island",-1,"","join");
+			if($this->islandManager->getIslandByOwner($player->getName()) !== null){
+				$form->addButton("§1Manage Your Island", -1, "", "manage");
+			}
+		}
+		$form->addButton("§1Visit an Island",-1,"","teleport");
+		$form->addButton("§1View Invitations",-1,"","view");
+		if($player->getLevel()->getName() !== Server::getInstance()->getDefaultLevel()->getName()){
+			$form->addButton("§1Go to Spawn", -1, "", "spawn");
+		}
+		$form->sendToPlayer($player);
+	}
+
+	public function handleGuestUI(Player $player, $data){
+		$result = $data;
+		if($result === null){
+			return;
+		}
+		if(is_array($result)){
+			$result = $result[0];
+		}
+		switch($result){
+			case "join":  $command = "join";
+				break;
+			case "create":  $command = "create";
+				break;
+			case "manage": $this->manageUI($player);
+				return;
+			case "teleport": $this->teleportUI($player);
+				return;
+			case "view": $this->viewInvitationsUI($player);
+				return;
+			case "spawn": $this->sendToSpawn($player);
+				return;
+			default: $this->handleSwitchError($player, "handleGuestUI", $result);
+				return;
+		}
+		$command = self::COMMAND_NAME . $command;
+		$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		return;
+	}
+
+	public function manageUI(Player $player){
+		$form = $this->formAPI->createSimpleForm([$this, "handleManageUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Manage Island");
+		$form->addButton("§1Invite", -1, "", "invite");
+		$island = $this->islandManager->getIslandByOwner($player->getName());
+		if($island !== null){
+			if($island->isOnIsland($player)){
+				$form->addButton("§1SetHome", -1, "", "sethome");
+				$form->addButton("§1Remove Member", -1, "", "remove");
+				$form->addButton("§1Change Owner", -1, "", "changeowner");
+			}
+		}
+		$form->addButton("§1Reset", -1, "", "reset");
+		$form->addButton("§1Delete", -1, "", "delete");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleManageUI(Player $player, $data){
+		$result = $data;
+		if($result === null){
+			return;
+		}
+		if(is_array($result)){
+			$result = $data[0];
+		}
+		switch($result){
+			case "invite":$this->inviteUI($player);
+				break;
+			case "sethome": $command = self::COMMAND_NAME . "sethome";
+				$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+				break;
+			case "remove": $this->removeMemberUI($player);
+				return;
+			case "changeowner": $this->changeOwnerUI($player);
+				return;
+			case "reset": $this->resetUI($player);
+				return;
+			case "delete": $this->deleteUI($player);
+				return;
+		}
+		return;
+	}
+
+	public function inviteUI($player){
+		$form = $this->formAPI->createCustomForm([$this, "handleInviteUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Invite");
+		$form->addInput("§aInvite a player", "name here");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleInviteUI(Player $player, $data){
+		$result = $data[0];
+		if($result === null){
+			return;
+		}
+		$playerToInvite = $this->plugin->getServer()->getPlayer($result);
+		if(!($playerToInvite instanceof Player)){
+			$this->sendMessage($player, "§c✖ $playerToInvite not found.  Please try again.");
+			return;
+		}
+		$command = self::COMMAND_NAME . "invite " . $result;
+		$config = $this->plugin->getSkyBlockManager()->getPlayerConfig($playerToInvite);
+		if(empty($config->get("island"))){
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}else{
+			$this->sendMessage($player, "§l§c✖§f §c$result is already in a island!");
+		}
+
+	}
+
+	public function generateModalForm(Player $player, string $title, string $handler, string $content){
+		$form = $this->formAPI->createModalForm([$this, $handler]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - " . $title);
+		$form->setContent($content);
+		$form->setButton1("§l§2✔ Confirm");
+		$form->setButton2("§l§c✖ Cancel");
+		$form->sendToPlayer($player);
+	}
+
+	public function viewInvitationsUI(Player $player){
+		$invitations =$this->invitationHandler->getInvitationByReceiver($player);
+		if($invitations === null){
+			$this->sendMessage($player, "§c✖§fYou don't currently have any invitations.");
+			return;
+		}
+		$form = $this->formAPI->createSimpleForm([$this, "handleViewInvitationsUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Invitations");
+		foreach($invitations as $invite){
+			$name = $invite->getSender()->getName();
+			$form->addButton("§1" . $name, -1, "", $name);
+		}
+		$form->addButton("§1Cancel", -1, "", "cancel");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleViewInvitationsUI(Player $player, $data){
+		$result = $data;
+		if($result === null or $result === "cancel"){
+			return;
+		}
+		$this->acceptUI($player, $result);
+	}
+
+	public function acceptUI(Player $player, $sender){
+
+		$invitations = $this->invitationHandler->getInvitationByReceiver($player);
+		$invitation = null;
+		foreach($invitations as $invite){
+			if($invite->getSender()->getName() == $sender){
+				$invitation = $invite;
+			}
+		}
+		if($invitation !== null){
+			$this->invitationPass[$player->getUniqueId()->toString()] = $invitation;
+			$handler = "handleAcceptUI";
+			$title = "Accept Invitation";
+			$content = "§3$sender §r has invited you to their Island. Would you like to join?";
+			$this->generateModalForm($player, $title, $handler, $content);
+		}else{
+			$this->sendMessage($player, "§l§c✖ The invitation from $sender no longer valid");
+		}
+	}
+
+	public function handleAcceptUI(Player $player, $data){
+		$result = $data;
+		if($result === null){
+			return;
+		}
+		if($result){
+			$this->invitationPass[$player->getUniqueId()->toString()]->accept();
+		}
+		return;
+	}
+
+	public function deleteUI($player){
+		$title = "Delete Island";
+		$handler = "handleDeleteUI";
+		$content = "Deleting your island will cause you to lose everything on the island.";
+		$content = $content . "\nIt will be 10 minutes before you can create another island.";
+		$content = $content . "\nThis cannot be undone.\n Continue?";
+		$this->generateModalForm($player, $title, $handler, $content);
+	}
+
+	public function handleDeleteUI(Player $player, $data){
+		$result = $data;
+		if($data === null){
+			return;
+		}
+		if($result){
+			$command = self::COMMAND_NAME . "disband";
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+		return;
+	}
+
+	public function removeMemberUI(Player $player){
+		// Probably a good idea to check this.
+		$island = $this->islandManager->getIslandByOwner($player->getName());
+		if($island instanceof Island){
+			$form = $this->formAPI->createSimpleForm([$this, "handleRemoveMemberUI"]);
+			$form->setTitle(self::BASE_TITLE . "§r§2 - Remove Member");
+			$members = $island->getMembers();
+			foreach($members as $member){
+				$form->addButton("§l§c✖ Kick \n" . $member, -1, "", $member);
+			}
+			$form->addButton("Cancel",-1, "", "cancel");
+			$form->sendToPlayer($player);
+		} else {
+			$this->sendMessage($player, "§l§c✖§f §cYou don't have an island!");
+			Server::getInstance()->getLogger()->error("removeMemberUI called with invalid Player argument.");
+		}
+		return;
+	}
+
+	public function handleRemoveMemberUI(Player $player, $data){
+		$result = $data;
+		if($result != null and $result !== "cancel"){
+			$command = self::COMMAND_NAME . "remove " . $result;
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+		return;
+	}
+
+	public function changeOwnerUI(Player $player){
+		$form = $this->formAPI->createCustomForm([$this, "handleChangeOwnerUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Change Owner");
+		$form->addInput("§aNew Owner's Name", "name here", null, "newOwner");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleChangeOwnerUI(Player $player, $data){
+		$result = $data;
+		if($result === null){
+			return;
+		}
+		$newOwner = Server::getInstance()->getPlayer($result["newOwner"]);
+		if(!($newOwner instanceof Player)){
+			$this->sendMessage($player, "{$result["newOwner"]} is not a valid player.  Please try again.");
+		}
+		$islandID = $this->islandManager->getIslandByOwner($player->getName())->getIdentifier();
+		$newOwnerConfig = Utils::getUserConfig($newOwner->getName());
+		if($newOwnerConfig !== null){
+			$newOwnerIsland = $newOwnerConfig->get("island");
+			if($newOwnerIsland !== "" and $newOwnerIsland !== $islandID){
+				$this->sendMessage($player, "{$newOwner->getName()} is already in an different island.");
+				$this->sendMessage($newOwner, "{$player->getName()} wants to give you an island but you're already a member on another island.");
+				return;
+			}
+		}
+		$this->ownerPass[$newOwner->getName()] = $player->getName();
+		$this->sendMessage($player, "Owner change request sent to {$newOwner->getName()}");
+		$this->confirmChangeOwnerUI($player, $newOwner);
+		return;
+
+	}
+
+	public function confirmChangeOwnerUI(Player $currentOwner, Player $newOwner){
+		$title = "Confirm Ownership";
+		$handler = "handleConfirmChangeOwnerUI";
+		$currentOwnerName = $currentOwner->getName();
+		$content = "$currentOwnerName would like to make you the owner of their island.  If you accept, they will stay a member until you remove them but will not be the owner anymore.";
+		$this->generateModalForm($newOwner, $title, $handler, $content);
+	}
+
+	public function handleConfirmChangeOwnerUI(Player $newOwner, $data){
+		$currentOwnerName = $this->ownerPass[$newOwner->getName()];
+		$currentOwner = Server::getInstance()->getPlayer($currentOwnerName);
+		if($data !== null and $data){
+			$island = $this->islandManager->getIslandByOwner($currentOwnerName);
+			if($island instanceof Island){
+				$island->setOwnerName($newOwner->getName());
+				$island->addMember($currentOwner);
+				$island->update();
+
+
+				$newOwnerConfig = $this->plugin->getSkyBlockManager()->getPlayerConfig($newOwner);
+				$newOwnerConfig->set("island", $island->getIdentifier());
+				$newOwnerConfig->save();
+				$this->sendMessage($currentOwner, "The island has been transferred successfully!");
+				$this->sendMessage($newOwner, "The island has been transferred successfully!");
+			}else{
+				$this->sendMessage($currentOwner, "Something went wrong with the transfer.");
+				$this->sendMessage($newOwner, "Something went wrong with the transfer.");
+			}
+		} else{
+			$this->sendMessage($currentOwner, "{$newOwner->getName()} did not accept your offer.");
+		}
+		unset($this->ownerPass[$newOwner->getName()]);
+		return;
+	}
+
+	public function resetUI($player){
+		$title = "Reset";
+		$handler = "handleResetUI";
+		$content = "This will remove everything on your island and leave you with only a basic starting island.";
+		$content = $content . "\nThis cannot be undone.\n Continue?";
+		$this->generateModalForm($player, $title, $handler, $content);
+	}
+
+	public function handleResetUI(Player $player, $data){
+		$result = $data;
+		if($result){
+			$command = self::COMMAND_NAME . "reset";
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+	}
+
+	public function teleportUI($player){
+		if($this->formAPI === null || $this->formAPI->isDisabled()){
+			return;
+		}
+		$form = $this->formAPI->createCustomForm([$this, "handleTeleportUI"]);
+		$form->setTitle(self::BASE_TITLE . "§r§2 - Teleport");
+		$form->addInput("§aTeleport to a player island", "name here");
+		$form->sendToPlayer($player);
+	}
+
+	public function handleTeleportUI(Player $player, $data){
+		$result = $data;
+		if($result != null){
+			$command = self::COMMAND_NAME . "tp " . $result[0];
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+	}
+
+	public function leaveUI(Player $player){
+		$handler = "handleLeaveUI";
+		$title = "Leave";
+		$content = "You will no longer be a member of this island.  Are you sure you want to leave?";
+		$this->generateModalForm($player, $title, $handler, $content);
+	}
+
+	public function handleLeaveUI(Player $player, $data){
+		if($data){
+			$command = self::COMMAND_NAME . "leave";
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+	}
+
+	public function kickUI(Player $player){
+		$island = $this->islandManager->getIslandByOwner($player->getName());
+		if($island instanceof Island){
+			$form = $this->formAPI->createSimpleForm([$this, "handleKickUI"]);
+			$form->setTitle(self::BASE_TITLE . "§r§2 - Kick");
+			$form->setContent("This will temporarily kick a player from your island.");
+			$members = $this->plugin->getServer()->getLevelByName($island->getIdentifier())->getPlayers();
+			foreach($members as $member){
+				if($member !== $player){
+					$memberName = $member->getName();
+					$form->addButton("§l§c✖ Kick \n" . $memberName, -1, "", $memberName);
+				}
+			}
+			$form->addButton("Cancel",-1, "", "cancel");
+			$form->sendToPlayer($player);
+		} else {
+			$this->sendMessage($player, "§l§c✖§f §cYou don't have an island!");
+			Server::getInstance()->getLogger()->error("kickUI called with invalid Player argument.");
+		}
+		return;
+	}
+
+	public function handleKickUI(Player $player, $data){
+		$result = $data;
+		if($result != null and $result !== "cancel"){
+			$command = self::COMMAND_NAME . "kick " . $result;
+			$this->plugin->getServer()->getCommandMap()->dispatch($player, $command);
+		}
+		return;
+	}
+
+	public function sendToSpawn(Player $player){
+		foreach($this->islandManager->getOnlineIslands() as $island){
+			$island->tryRemovePlayer($player);
+		}
+		$pos = Server::getInstance()->getDefaultLevel()->getSafeSpawn();
+		$player->teleport($pos);
+		return;
+	}
+
+	public function handleSwitchError(Player $player, string $sourceName, string $result){
+		Server::getInstance()->getLogger()->error("$sourceName returned unhandled result $result");
+		$player->sendMessage("§cOops, SkyBlock had an error processing your request.");
+		return;
+	}
+}


### PR DESCRIPTION
This PR will update methods to work properly with 3.0.X versions of PocketMine-MP.

Feature updates.
 - Add Configurable Chest Contents
 - Add Configurable Cobblegen Drops
 - Add Ability to Define Protected Worlds for `/sbcleanup`

Bug Fixes:
 - Fix Errors related to missing SkyBlockForms class.
 - Resolve Error when creating islands on servers that aren't using FormAPI.
 - Remove incorrect item in DocBlock comment from accidental refactor.
 - Cleanup enable and disable messages.